### PR TITLE
Update message about pgOmitListSuffix

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = function PgSimplifyInflectorPlugin(builder, { pgSimpleCollectio
     throw new Error("Cannot omit -list suffix (`pgOmitListSuffix`) if both relay connections and simple collections are enabled.");
   }
   if (hasSimpleCollections && !hasConnections && pgOmitListSuffix !== true && pgOmitListSuffix !== false) {
-    console.warn("You can simplify the inflector further by adding `{graphileOptions: {pgOmitListSuffix: true}}` to the options passed to PostGraphile, however be aware that doing so will mean that later enabling relay connections will be a breaking change. To dismiss this message, set `pgOmitListSuffix` to false instead.");
+    console.warn("You can simplify the inflector further by adding `{graphileBuildOptions: {pgOmitListSuffix: true}}` to the options passed to PostGraphile, however be aware that doing so will mean that later enabling relay connections will be a breaking change. To dismiss this message, set `pgOmitListSuffix` to false instead.");
   }
 
   builder.hook("inflection", inflection => {


### PR DESCRIPTION
The message suggesting how to add `pgOmitListSuffix` to omit `List` suffix was out of date.