### PR TITLE
Omit list suffix for root queries

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ module.exports = function PgSimplifyInflectorPlugin(
             },
             allRowsSimple(table) {
               return this.camelCase(
-                `${this.pluralize(this._singularizedTableName(table))}-list`
+                this.pluralize(this._singularizedTableName(table)) + (pgOmitListSuffix ? "" : "-list")
               );
             },
           }


### PR DESCRIPTION
Omits list suffix for root queries as well when the `pgOmitListSuffix` flag is set.