### PR TITLE
Omit list suffix for computed fields

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,6 +145,16 @@ module.exports = function PgSimplifyInflectorPlugin(
             },
           }
         : null),
+      
+      computedColumnList(
+        pseudoColumnName,
+        proc,
+        _table,
+      ) {
+        return proc.tags.fieldName
+          ? proc.tags.fieldName +  (pgOmitListSuffix ? "" : "List")
+          : this.camelCase(pseudoColumnName + (pgOmitListSuffix ? "" : "-list"));
+      },
 
       singleRelationByKeys(detailedKeys, table, _foreignTable, constraint) {
         if (constraint.tags.fieldName) {


### PR DESCRIPTION
Omits list suffix for computed fields when the pgOmitListSuffix flag is set.

Similar to https://github.com/graphile-contrib/pg-simplify-inflector/pull/13

It's a breaking change as well so would be great to have it merged before `4.0.0`.