### PR TITLE
Run pluralize on only the last segment of a name

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,13 +7,14 @@ function fixCapitalisedPlural(fn) {
 
 function fixChangePlural(fn) {
   return function(str) {
-    const matches = str.match(/[A-Z_][a-z0-9]*$/);
-    const index = matches ? matches.index : 0;
-    const hasUnderscore = matches && matches[0].startsWith("_");
-    const splitIndex = hasUnderscore ? index + 1 : index;
-    const prefix = str.substr(0, splitIndex);
-    const word = str.substr(splitIndex);
-    return `${prefix}${fn(word)}`;
+    const matches = str.match(/([A-Z]|_[a-z0-9])[a-z0-9]*_*$/);
+    const index = matches ? matches.index + matches[1].length - 1 : 0;
+    const suffixMatches = str.match(/_*$/);
+    const suffixIndex = suffixMatches.index;
+    const prefix = str.substr(0, index);
+    const word = str.substr(index, suffixIndex - index);
+    const suffix = str.substr(suffixIndex);
+    return `${prefix}${fn.call(this, word)}${suffix}`;
   };
 }
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,18 @@ function fixCapitalisedPlural(fn) {
   };
 }
 
+function fixChangePlural(fn) {
+  return function(str) {
+    const matches = str.match(/[A-Z_][a-z0-9]*$/);
+    const index = matches ? matches.index : 0;
+    const hasUnderscore = matches && matches[0].startsWith("_");
+    const splitIndex = hasUnderscore ? index + 1 : index;
+    const prefix = str.substr(0, splitIndex);
+    const word = str.substr(splitIndex);
+    return `${prefix}${fn(word)}`;
+  };
+}
+
 function PgSimplifyInflectorPlugin(
   builder,
   {
@@ -47,6 +59,13 @@ function PgSimplifyInflectorPlugin(
        */
       camelCase: fixCapitalisedPlural(oldInflection.camelCase),
       upperCamelCase: fixCapitalisedPlural(oldInflection.upperCamelCase),
+
+      /*
+       * Pluralize/singularize only supports single words, so only run
+       * on the final segment of a name.
+       */
+      pluralize: fixChangePlural(oldInflection.pluralize),
+      singularize: fixChangePlural(oldInflection.singularize),
 
       distinctPluralize(str) {
         const singular = this.singularize(str);

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "index.d.ts"
   ],
   "devDependencies": {
-    "postgraphile": "^4.2.0",
+    "postgraphile": "4.4.1",
     "prettier": "^1.14.3"
   }
 }

--- a/schema.diff
+++ b/schema.diff
@@ -1,0 +1,1208 @@
+--- ./schema.graphql	2019-06-23 18:08:40.000000000 +0100
++++ ./schema.simplified.graphql	2019-06-23 18:08:40.000000000 +0100
+@@ -9,10 +9,10 @@
+   name: String!
+ 
+   """Reads a single `Company` that is related to this `Beverage`."""
+-  companyByCompanyId: Company
++  company: Company
+ 
+   """Reads a single `Company` that is related to this `Beverage`."""
+-  companyByDistributorId: Company
++  distributor: Company
+ }
+ 
+ """
+@@ -138,7 +138,7 @@
+   name: String!
+ 
+   """Reads and enables pagination through a set of `Beverage`."""
+-  beveragesByCompanyId(
++  beverages(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -167,7 +167,7 @@
+   ): BeveragesConnection!
+ 
+   """Reads and enables pagination through a set of `Beverage`."""
+-  beveragesByCompanyIdList(
++  beveragesList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -284,10 +284,10 @@
+   query: Query
+ 
+   """Reads a single `Company` that is related to this `Beverage`."""
+-  companyByCompanyId: Company
++  company: Company
+ 
+   """Reads a single `Company` that is related to this `Beverage`."""
+-  companyByDistributorId: Company
++  distributor: Company
+ 
+   """An edge for our `Beverage`. May be used by Relay 1."""
+   beverageEdge(
+@@ -360,7 +360,7 @@
+   query: Query
+ 
+   """Reads a single `Pond` that is related to this `Fish`."""
+-  pondByPondId: Pond
++  pond: Pond
+ 
+   """An edge for our `Fish`. May be used by Relay 1."""
+   fishEdge(
+@@ -369,39 +369,39 @@
+   ): FishEdge
+ }
+ 
+-"""All input for the create `FooGenera` mutation."""
+-input CreateFooGeneraInput {
++"""All input for the create `FooGenus` mutation."""
++input CreateFooGenusInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+ 
+-  """The `FooGenera` to be created by this mutation."""
+-  fooGenera: FooGeneraInput!
++  """The `FooGenus` to be created by this mutation."""
++  fooGenus: FooGenusInput!
+ }
+ 
+-"""The output of our create `FooGenera` mutation."""
+-type CreateFooGeneraPayload {
++"""The output of our create `FooGenus` mutation."""
++type CreateFooGenusPayload {
+   """
+   The exact same `clientMutationId` that was provided in the mutation input,
+   unchanged and unused. May be used by a client to track mutations.
+   """
+   clientMutationId: String
+ 
+-  """The `FooGenera` that was created by this mutation."""
+-  fooGenera: FooGenera
++  """The `FooGenus` that was created by this mutation."""
++  fooGenus: FooGenus
+ 
+   """
+   Our root query field type. Allows us to run any query from our mutation payload.
+   """
+   query: Query
+ 
+-  """An edge for our `FooGenera`. May be used by Relay 1."""
+-  fooGeneraEdge(
+-    """The method to use when ordering `FooGenera`."""
+-    orderBy: [FooGenerasOrderBy!] = PRIMARY_KEY_ASC
+-  ): FooGenerasEdge
++  """An edge for our `FooGenus`. May be used by Relay 1."""
++  fooGenusEdge(
++    """The method to use when ordering `FooGenus`."""
++    orderBy: [FooGeneraOrderBy!] = PRIMARY_KEY_ASC
++  ): FooGeneraEdge
+ }
+ 
+ """All input for the create `Pond` mutation."""
+@@ -442,14 +442,18 @@
+ """A location in a connection that can be used for resuming pagination."""
+ scalar Cursor
+ 
+-"""All input for the `deleteBeverageById` mutation."""
+-input DeleteBeverageByIdInput {
++"""All input for the `deleteBeverageByNodeId` mutation."""
++input DeleteBeverageByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-  id: Int!
++
++  """
++  The globally unique `ID` which will identify a single `Beverage` to be deleted.
++  """
++  nodeId: ID!
+ }
+ 
+ """All input for the `deleteBeverage` mutation."""
+@@ -459,11 +463,7 @@
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-
+-  """
+-  The globally unique `ID` which will identify a single `Beverage` to be deleted.
+-  """
+-  nodeId: ID!
++  id: Int!
+ }
+ 
+ """The output of our delete `Beverage` mutation."""
+@@ -476,7 +476,7 @@
+ 
+   """The `Beverage` that was deleted by this mutation."""
+   beverage: Beverage
+-  deletedBeverageId: ID
++  deletedBeverageNodeId: ID
+ 
+   """
+   Our root query field type. Allows us to run any query from our mutation payload.
+@@ -484,10 +484,10 @@
+   query: Query
+ 
+   """Reads a single `Company` that is related to this `Beverage`."""
+-  companyByCompanyId: Company
++  company: Company
+ 
+   """Reads a single `Company` that is related to this `Beverage`."""
+-  companyByDistributorId: Company
++  distributor: Company
+ 
+   """An edge for our `Beverage`. May be used by Relay 1."""
+   beverageEdge(
+@@ -496,14 +496,18 @@
+   ): BeveragesEdge
+ }
+ 
+-"""All input for the `deleteCompanyById` mutation."""
+-input DeleteCompanyByIdInput {
++"""All input for the `deleteCompanyByNodeId` mutation."""
++input DeleteCompanyByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-  id: Int!
++
++  """
++  The globally unique `ID` which will identify a single `Company` to be deleted.
++  """
++  nodeId: ID!
+ }
+ 
+ """All input for the `deleteCompany` mutation."""
+@@ -513,11 +517,7 @@
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-
+-  """
+-  The globally unique `ID` which will identify a single `Company` to be deleted.
+-  """
+-  nodeId: ID!
++  id: Int!
+ }
+ 
+ """The output of our delete `Company` mutation."""
+@@ -530,7 +530,7 @@
+ 
+   """The `Company` that was deleted by this mutation."""
+   company: Company
+-  deletedCompanyId: ID
++  deletedCompanyNodeId: ID
+ 
+   """
+   Our root query field type. Allows us to run any query from our mutation payload.
+@@ -544,14 +544,18 @@
+   ): CompaniesEdge
+ }
+ 
+-"""All input for the `deleteFishById` mutation."""
+-input DeleteFishByIdInput {
++"""All input for the `deleteFishByNodeId` mutation."""
++input DeleteFishByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-  id: Int!
++
++  """
++  The globally unique `ID` which will identify a single `Fish` to be deleted.
++  """
++  nodeId: ID!
+ }
+ 
+ """All input for the `deleteFish` mutation."""
+@@ -561,11 +565,7 @@
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-
+-  """
+-  The globally unique `ID` which will identify a single `Fish` to be deleted.
+-  """
+-  nodeId: ID!
++  id: Int!
+ }
+ 
+ """The output of our delete `Fish` mutation."""
+@@ -578,7 +578,7 @@
+ 
+   """The `Fish` that was deleted by this mutation."""
+   fish: Fish
+-  deletedFishId: ID
++  deletedFishNodeId: ID
+ 
+   """
+   Our root query field type. Allows us to run any query from our mutation payload.
+@@ -586,7 +586,7 @@
+   query: Query
+ 
+   """Reads a single `Pond` that is related to this `Fish`."""
+-  pondByPondId: Pond
++  pond: Pond
+ 
+   """An edge for our `Fish`. May be used by Relay 1."""
+   fishEdge(
+@@ -595,62 +595,66 @@
+   ): FishEdge
+ }
+ 
+-"""All input for the `deleteFooGeneraById` mutation."""
+-input DeleteFooGeneraByIdInput {
++"""All input for the `deleteFooGenusByNodeId` mutation."""
++input DeleteFooGenusByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-  id: Int!
++
++  """
++  The globally unique `ID` which will identify a single `FooGenus` to be deleted.
++  """
++  nodeId: ID!
+ }
+ 
+-"""All input for the `deleteFooGenera` mutation."""
+-input DeleteFooGeneraInput {
++"""All input for the `deleteFooGenus` mutation."""
++input DeleteFooGenusInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-
+-  """
+-  The globally unique `ID` which will identify a single `FooGenera` to be deleted.
+-  """
+-  nodeId: ID!
++  id: Int!
+ }
+ 
+-"""The output of our delete `FooGenera` mutation."""
+-type DeleteFooGeneraPayload {
++"""The output of our delete `FooGenus` mutation."""
++type DeleteFooGenusPayload {
+   """
+   The exact same `clientMutationId` that was provided in the mutation input,
+   unchanged and unused. May be used by a client to track mutations.
+   """
+   clientMutationId: String
+ 
+-  """The `FooGenera` that was deleted by this mutation."""
+-  fooGenera: FooGenera
+-  deletedFooGeneraId: ID
++  """The `FooGenus` that was deleted by this mutation."""
++  fooGenus: FooGenus
++  deletedFooGenusNodeId: ID
+ 
+   """
+   Our root query field type. Allows us to run any query from our mutation payload.
+   """
+   query: Query
+ 
+-  """An edge for our `FooGenera`. May be used by Relay 1."""
+-  fooGeneraEdge(
+-    """The method to use when ordering `FooGenera`."""
+-    orderBy: [FooGenerasOrderBy!] = PRIMARY_KEY_ASC
+-  ): FooGenerasEdge
++  """An edge for our `FooGenus`. May be used by Relay 1."""
++  fooGenusEdge(
++    """The method to use when ordering `FooGenus`."""
++    orderBy: [FooGeneraOrderBy!] = PRIMARY_KEY_ASC
++  ): FooGeneraEdge
+ }
+ 
+-"""All input for the `deletePondById` mutation."""
+-input DeletePondByIdInput {
++"""All input for the `deletePondByNodeId` mutation."""
++input DeletePondByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-  id: Int!
++
++  """
++  The globally unique `ID` which will identify a single `Pond` to be deleted.
++  """
++  nodeId: ID!
+ }
+ 
+ """All input for the `deletePond` mutation."""
+@@ -660,11 +664,7 @@
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-
+-  """
+-  The globally unique `ID` which will identify a single `Pond` to be deleted.
+-  """
+-  nodeId: ID!
++  id: Int!
+ }
+ 
+ """The output of our delete `Pond` mutation."""
+@@ -677,7 +677,7 @@
+ 
+   """The `Pond` that was deleted by this mutation."""
+   pond: Pond
+-  deletedPondId: ID
++  deletedPondNodeId: ID
+ 
+   """
+   Our root query field type. Allows us to run any query from our mutation payload.
+@@ -701,7 +701,7 @@
+   name: String!
+ 
+   """Reads a single `Pond` that is related to this `Fish`."""
+-  pondByPondId: Pond
++  pond: Pond
+ }
+ 
+ """
+@@ -773,7 +773,44 @@
+   name: String
+ }
+ 
+-type FooGenera implements Node {
++"""A connection to a list of `FooGenus` values."""
++type FooGeneraConnection {
++  """A list of `FooGenus` objects."""
++  nodes: [FooGenus]!
++
++  """
++  A list of edges which contains the `FooGenus` and cursor to aid in pagination.
++  """
++  edges: [FooGeneraEdge!]!
++
++  """Information to aid in pagination."""
++  pageInfo: PageInfo!
++
++  """The count of *all* `FooGenus` you could get from the connection."""
++  totalCount: Int!
++}
++
++"""A `FooGenus` edge in the connection."""
++type FooGeneraEdge {
++  """A cursor for use in pagination."""
++  cursor: Cursor
++
++  """The `FooGenus` at the end of the edge."""
++  node: FooGenus
++}
++
++"""Methods to use when ordering `FooGenus`."""
++enum FooGeneraOrderBy {
++  NATURAL
++  ID_ASC
++  ID_DESC
++  NAME_ASC
++  NAME_DESC
++  PRIMARY_KEY_ASC
++  PRIMARY_KEY_DESC
++}
++
++type FooGenus implements Node {
+   """
+   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+   """
+@@ -783,10 +820,10 @@
+ }
+ 
+ """
+-A condition to be used against `FooGenera` object types. All fields are tested
++A condition to be used against `FooGenus` object types. All fields are tested
+ for equality and combined with a logical ‘and.’
+ """
+-input FooGeneraCondition {
++input FooGenusCondition {
+   """Checks for equality with the object’s `id` field."""
+   id: Int
+ 
+@@ -794,57 +831,20 @@
+   name: String
+ }
+ 
+-"""An input for mutations affecting `FooGenera`"""
+-input FooGeneraInput {
++"""An input for mutations affecting `FooGenus`"""
++input FooGenusInput {
+   id: Int
+   name: String!
+ }
+ 
+ """
+-Represents an update to a `FooGenera`. Fields that are set will be updated.
++Represents an update to a `FooGenus`. Fields that are set will be updated.
+ """
+-input FooGeneraPatch {
++input FooGenusPatch {
+   id: Int
+   name: String
+ }
+ 
+-"""A connection to a list of `FooGenera` values."""
+-type FooGenerasConnection {
+-  """A list of `FooGenera` objects."""
+-  nodes: [FooGenera]!
+-
+-  """
+-  A list of edges which contains the `FooGenera` and cursor to aid in pagination.
+-  """
+-  edges: [FooGenerasEdge!]!
+-
+-  """Information to aid in pagination."""
+-  pageInfo: PageInfo!
+-
+-  """The count of *all* `FooGenera` you could get from the connection."""
+-  totalCount: Int!
+-}
+-
+-"""A `FooGenera` edge in the connection."""
+-type FooGenerasEdge {
+-  """A cursor for use in pagination."""
+-  cursor: Cursor
+-
+-  """The `FooGenera` at the end of the edge."""
+-  node: FooGenera
+-}
+-
+-"""Methods to use when ordering `FooGenera`."""
+-enum FooGenerasOrderBy {
+-  NATURAL
+-  ID_ASC
+-  ID_DESC
+-  NAME_ASC
+-  NAME_DESC
+-  PRIMARY_KEY_ASC
+-  PRIMARY_KEY_DESC
+-}
+-
+ """
+ The root mutation type which contains root level fields which mutate data.
+ """
+@@ -873,13 +873,13 @@
+     input: CreateFishInput!
+   ): CreateFishPayload
+ 
+-  """Creates a single `FooGenera`."""
+-  createFooGenera(
++  """Creates a single `FooGenus`."""
++  createFooGenus(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: CreateFooGeneraInput!
+-  ): CreateFooGeneraPayload
++    input: CreateFooGenusInput!
++  ): CreateFooGenusPayload
+ 
+   """Creates a single `Pond`."""
+   createPond(
+@@ -890,165 +890,163 @@
+   ): CreatePondPayload
+ 
+   """Updates a single `Beverage` using its globally unique id and a patch."""
+-  updateBeverage(
++  updateBeverageByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateBeverageInput!
++    input: UpdateBeverageByNodeIdInput!
+   ): UpdateBeveragePayload
+ 
+   """Updates a single `Beverage` using a unique key and a patch."""
+-  updateBeverageById(
++  updateBeverage(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateBeverageByIdInput!
++    input: UpdateBeverageInput!
+   ): UpdateBeveragePayload
+ 
+   """Updates a single `Company` using its globally unique id and a patch."""
+-  updateCompany(
++  updateCompanyByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateCompanyInput!
++    input: UpdateCompanyByNodeIdInput!
+   ): UpdateCompanyPayload
+ 
+   """Updates a single `Company` using a unique key and a patch."""
+-  updateCompanyById(
++  updateCompany(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateCompanyByIdInput!
++    input: UpdateCompanyInput!
+   ): UpdateCompanyPayload
+ 
+   """Updates a single `Fish` using its globally unique id and a patch."""
+-  updateFish(
++  updateFishByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateFishInput!
++    input: UpdateFishByNodeIdInput!
+   ): UpdateFishPayload
+ 
+   """Updates a single `Fish` using a unique key and a patch."""
+-  updateFishById(
++  updateFish(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateFishByIdInput!
++    input: UpdateFishInput!
+   ): UpdateFishPayload
+ 
+-  """
+-  Updates a single `FooGenera` using its globally unique id and a patch.
+-  """
+-  updateFooGenera(
++  """Updates a single `FooGenus` using its globally unique id and a patch."""
++  updateFooGenusByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateFooGeneraInput!
+-  ): UpdateFooGeneraPayload
++    input: UpdateFooGenusByNodeIdInput!
++  ): UpdateFooGenusPayload
+ 
+-  """Updates a single `FooGenera` using a unique key and a patch."""
+-  updateFooGeneraById(
++  """Updates a single `FooGenus` using a unique key and a patch."""
++  updateFooGenus(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateFooGeneraByIdInput!
+-  ): UpdateFooGeneraPayload
++    input: UpdateFooGenusInput!
++  ): UpdateFooGenusPayload
+ 
+   """Updates a single `Pond` using its globally unique id and a patch."""
+-  updatePond(
++  updatePondByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdatePondInput!
++    input: UpdatePondByNodeIdInput!
+   ): UpdatePondPayload
+ 
+   """Updates a single `Pond` using a unique key and a patch."""
+-  updatePondById(
++  updatePond(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdatePondByIdInput!
++    input: UpdatePondInput!
+   ): UpdatePondPayload
+ 
+   """Deletes a single `Beverage` using its globally unique id."""
+-  deleteBeverage(
++  deleteBeverageByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteBeverageInput!
++    input: DeleteBeverageByNodeIdInput!
+   ): DeleteBeveragePayload
+ 
+   """Deletes a single `Beverage` using a unique key."""
+-  deleteBeverageById(
++  deleteBeverage(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteBeverageByIdInput!
++    input: DeleteBeverageInput!
+   ): DeleteBeveragePayload
+ 
+   """Deletes a single `Company` using its globally unique id."""
+-  deleteCompany(
++  deleteCompanyByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteCompanyInput!
++    input: DeleteCompanyByNodeIdInput!
+   ): DeleteCompanyPayload
+ 
+   """Deletes a single `Company` using a unique key."""
+-  deleteCompanyById(
++  deleteCompany(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteCompanyByIdInput!
++    input: DeleteCompanyInput!
+   ): DeleteCompanyPayload
+ 
+   """Deletes a single `Fish` using its globally unique id."""
+-  deleteFish(
++  deleteFishByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteFishInput!
++    input: DeleteFishByNodeIdInput!
+   ): DeleteFishPayload
+ 
+   """Deletes a single `Fish` using a unique key."""
+-  deleteFishById(
++  deleteFish(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteFishByIdInput!
++    input: DeleteFishInput!
+   ): DeleteFishPayload
+ 
+-  """Deletes a single `FooGenera` using its globally unique id."""
+-  deleteFooGenera(
++  """Deletes a single `FooGenus` using its globally unique id."""
++  deleteFooGenusByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteFooGeneraInput!
+-  ): DeleteFooGeneraPayload
++    input: DeleteFooGenusByNodeIdInput!
++  ): DeleteFooGenusPayload
+ 
+-  """Deletes a single `FooGenera` using a unique key."""
+-  deleteFooGeneraById(
++  """Deletes a single `FooGenus` using a unique key."""
++  deleteFooGenus(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteFooGeneraByIdInput!
+-  ): DeleteFooGeneraPayload
++    input: DeleteFooGenusInput!
++  ): DeleteFooGenusPayload
+ 
+   """Deletes a single `Pond` using its globally unique id."""
+-  deletePond(
++  deletePondByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeletePondInput!
++    input: DeletePondByNodeIdInput!
+   ): DeletePondPayload
+ 
+   """Deletes a single `Pond` using a unique key."""
+-  deletePondById(
++  deletePond(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeletePondByIdInput!
++    input: DeletePondInput!
+   ): DeletePondPayload
+ }
+ 
+@@ -1084,7 +1082,7 @@
+   name: String!
+ 
+   """Reads and enables pagination through a set of `Fish`."""
+-  fishByPondId(
++  fishes(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1113,7 +1111,7 @@
+   ): FishConnection!
+ 
+   """Reads and enables pagination through a set of `Fish`."""
+-  fishByPondIdList(
++  fishesList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1212,7 +1210,7 @@
+   ): Node
+ 
+   """Reads and enables pagination through a set of `Beverage`."""
+-  allBeverages(
++  beverages(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1241,7 +1239,7 @@
+   ): BeveragesConnection
+ 
+   """Reads a set of `Beverage`."""
+-  allBeveragesList(
++  beveragesList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1258,7 +1256,7 @@
+   ): [Beverage!]
+ 
+   """Reads and enables pagination through a set of `Company`."""
+-  allCompanies(
++  companies(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1287,7 +1285,7 @@
+   ): CompaniesConnection
+ 
+   """Reads a set of `Company`."""
+-  allCompaniesList(
++  companiesList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1304,7 +1302,7 @@
+   ): [Company!]
+ 
+   """Reads and enables pagination through a set of `Fish`."""
+-  allFish(
++  fishes(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1333,7 +1331,7 @@
+   ): FishConnection
+ 
+   """Reads a set of `Fish`."""
+-  allFishList(
++  fishesList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1349,8 +1347,8 @@
+     condition: FishCondition
+   ): [Fish!]
+ 
+-  """Reads and enables pagination through a set of `FooGenera`."""
+-  allFooGeneras(
++  """Reads and enables pagination through a set of `FooGenus`."""
++  fooGenera(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1369,34 +1367,34 @@
+     """Read all values in the set after (below) this cursor."""
+     after: Cursor
+ 
+-    """The method to use when ordering `FooGenera`."""
+-    orderBy: [FooGenerasOrderBy!] = [PRIMARY_KEY_ASC]
++    """The method to use when ordering `FooGenus`."""
++    orderBy: [FooGeneraOrderBy!] = [PRIMARY_KEY_ASC]
+ 
+     """
+     A condition to be used in determining which values should be returned by the collection.
+     """
+-    condition: FooGeneraCondition
+-  ): FooGenerasConnection
++    condition: FooGenusCondition
++  ): FooGeneraConnection
+ 
+-  """Reads a set of `FooGenera`."""
+-  allFooGenerasList(
++  """Reads a set of `FooGenus`."""
++  fooGeneraList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+     """Skip the first `n` values."""
+     offset: Int
+ 
+-    """The method to use when ordering `FooGenera`."""
+-    orderBy: [FooGenerasOrderBy!]
++    """The method to use when ordering `FooGenus`."""
++    orderBy: [FooGeneraOrderBy!]
+ 
+     """
+     A condition to be used in determining which values should be returned by the collection.
+     """
+-    condition: FooGeneraCondition
+-  ): [FooGenera!]
++    condition: FooGenusCondition
++  ): [FooGenus!]
+ 
+   """Reads and enables pagination through a set of `Pond`."""
+-  allPonds(
++  ponds(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1425,7 +1423,7 @@
+   ): PondsConnection
+ 
+   """Reads a set of `Pond`."""
+-  allPondsList(
++  pondsList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1440,47 +1438,45 @@
+     """
+     condition: PondCondition
+   ): [Pond!]
+-  beverageById(id: Int!): Beverage
+-  companyById(id: Int!): Company
+-  fishById(id: Int!): Fish
+-  fooGeneraById(id: Int!): FooGenera
+-  pondById(id: Int!): Pond
++  beverage(id: Int!): Beverage
++  company(id: Int!): Company
++  fish(id: Int!): Fish
++  fooGenus(id: Int!): FooGenus
++  pond(id: Int!): Pond
+ 
+   """Reads a single `Beverage` using its globally unique `ID`."""
+-  beverage(
++  beverageByNodeId(
+     """The globally unique `ID` to be used in selecting a single `Beverage`."""
+     nodeId: ID!
+   ): Beverage
+ 
+   """Reads a single `Company` using its globally unique `ID`."""
+-  company(
++  companyByNodeId(
+     """The globally unique `ID` to be used in selecting a single `Company`."""
+     nodeId: ID!
+   ): Company
+ 
+   """Reads a single `Fish` using its globally unique `ID`."""
+-  fish(
++  fishByNodeId(
+     """The globally unique `ID` to be used in selecting a single `Fish`."""
+     nodeId: ID!
+   ): Fish
+ 
+-  """Reads a single `FooGenera` using its globally unique `ID`."""
+-  fooGenera(
+-    """
+-    The globally unique `ID` to be used in selecting a single `FooGenera`.
+-    """
++  """Reads a single `FooGenus` using its globally unique `ID`."""
++  fooGenusByNodeId(
++    """The globally unique `ID` to be used in selecting a single `FooGenus`."""
+     nodeId: ID!
+-  ): FooGenera
++  ): FooGenus
+ 
+   """Reads a single `Pond` using its globally unique `ID`."""
+-  pond(
++  pondByNodeId(
+     """The globally unique `ID` to be used in selecting a single `Pond`."""
+     nodeId: ID!
+   ): Pond
+ }
+ 
+-"""All input for the `updateBeverageById` mutation."""
+-input UpdateBeverageByIdInput {
++"""All input for the `updateBeverageByNodeId` mutation."""
++input UpdateBeverageByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+@@ -1488,10 +1484,14 @@
+   clientMutationId: String
+ 
+   """
++  The globally unique `ID` which will identify a single `Beverage` to be updated.
++  """
++  nodeId: ID!
++
++  """
+   An object where the defined keys will be set on the `Beverage` being updated.
+   """
+-  beveragePatch: BeveragePatch!
+-  id: Int!
++  patch: BeveragePatch!
+ }
+ 
+ """All input for the `updateBeverage` mutation."""
+@@ -1503,14 +1503,10 @@
+   clientMutationId: String
+ 
+   """
+-  The globally unique `ID` which will identify a single `Beverage` to be updated.
+-  """
+-  nodeId: ID!
+-
+-  """
+   An object where the defined keys will be set on the `Beverage` being updated.
+   """
+-  beveragePatch: BeveragePatch!
++  patch: BeveragePatch!
++  id: Int!
+ }
+ 
+ """The output of our update `Beverage` mutation."""
+@@ -1530,10 +1526,10 @@
+   query: Query
+ 
+   """Reads a single `Company` that is related to this `Beverage`."""
+-  companyByCompanyId: Company
++  company: Company
+ 
+   """Reads a single `Company` that is related to this `Beverage`."""
+-  companyByDistributorId: Company
++  distributor: Company
+ 
+   """An edge for our `Beverage`. May be used by Relay 1."""
+   beverageEdge(
+@@ -1542,8 +1538,8 @@
+   ): BeveragesEdge
+ }
+ 
+-"""All input for the `updateCompanyById` mutation."""
+-input UpdateCompanyByIdInput {
++"""All input for the `updateCompanyByNodeId` mutation."""
++input UpdateCompanyByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+@@ -1551,10 +1547,14 @@
+   clientMutationId: String
+ 
+   """
++  The globally unique `ID` which will identify a single `Company` to be updated.
++  """
++  nodeId: ID!
++
++  """
+   An object where the defined keys will be set on the `Company` being updated.
+   """
+-  companyPatch: CompanyPatch!
+-  id: Int!
++  patch: CompanyPatch!
+ }
+ 
+ """All input for the `updateCompany` mutation."""
+@@ -1566,14 +1566,10 @@
+   clientMutationId: String
+ 
+   """
+-  The globally unique `ID` which will identify a single `Company` to be updated.
+-  """
+-  nodeId: ID!
+-
+-  """
+   An object where the defined keys will be set on the `Company` being updated.
+   """
+-  companyPatch: CompanyPatch!
++  patch: CompanyPatch!
++  id: Int!
+ }
+ 
+ """The output of our update `Company` mutation."""
+@@ -1599,8 +1595,8 @@
+   ): CompaniesEdge
+ }
+ 
+-"""All input for the `updateFishById` mutation."""
+-input UpdateFishByIdInput {
++"""All input for the `updateFishByNodeId` mutation."""
++input UpdateFishByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+@@ -1608,10 +1604,14 @@
+   clientMutationId: String
+ 
+   """
++  The globally unique `ID` which will identify a single `Fish` to be updated.
++  """
++  nodeId: ID!
++
++  """
+   An object where the defined keys will be set on the `Fish` being updated.
+   """
+-  fishPatch: FishPatch!
+-  id: Int!
++  patch: FishPatch!
+ }
+ 
+ """All input for the `updateFish` mutation."""
+@@ -1623,14 +1623,10 @@
+   clientMutationId: String
+ 
+   """
+-  The globally unique `ID` which will identify a single `Fish` to be updated.
+-  """
+-  nodeId: ID!
+-
+-  """
+   An object where the defined keys will be set on the `Fish` being updated.
+   """
+-  fishPatch: FishPatch!
++  patch: FishPatch!
++  id: Int!
+ }
+ 
+ """The output of our update `Fish` mutation."""
+@@ -1650,7 +1646,7 @@
+   query: Query
+ 
+   """Reads a single `Pond` that is related to this `Fish`."""
+-  pondByPondId: Pond
++  pond: Pond
+ 
+   """An edge for our `Fish`. May be used by Relay 1."""
+   fishEdge(
+@@ -1659,8 +1655,8 @@
+   ): FishEdge
+ }
+ 
+-"""All input for the `updateFooGeneraById` mutation."""
+-input UpdateFooGeneraByIdInput {
++"""All input for the `updateFooGenusByNodeId` mutation."""
++input UpdateFooGenusByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+@@ -1668,14 +1664,18 @@
+   clientMutationId: String
+ 
+   """
+-  An object where the defined keys will be set on the `FooGenera` being updated.
++  The globally unique `ID` which will identify a single `FooGenus` to be updated.
+   """
+-  fooGeneraPatch: FooGeneraPatch!
+-  id: Int!
++  nodeId: ID!
++
++  """
++  An object where the defined keys will be set on the `FooGenus` being updated.
++  """
++  patch: FooGenusPatch!
+ }
+ 
+-"""All input for the `updateFooGenera` mutation."""
+-input UpdateFooGeneraInput {
++"""All input for the `updateFooGenus` mutation."""
++input UpdateFooGenusInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+@@ -1683,41 +1683,37 @@
+   clientMutationId: String
+ 
+   """
+-  The globally unique `ID` which will identify a single `FooGenera` to be updated.
+-  """
+-  nodeId: ID!
+-
+-  """
+-  An object where the defined keys will be set on the `FooGenera` being updated.
++  An object where the defined keys will be set on the `FooGenus` being updated.
+   """
+-  fooGeneraPatch: FooGeneraPatch!
++  patch: FooGenusPatch!
++  id: Int!
+ }
+ 
+-"""The output of our update `FooGenera` mutation."""
+-type UpdateFooGeneraPayload {
++"""The output of our update `FooGenus` mutation."""
++type UpdateFooGenusPayload {
+   """
+   The exact same `clientMutationId` that was provided in the mutation input,
+   unchanged and unused. May be used by a client to track mutations.
+   """
+   clientMutationId: String
+ 
+-  """The `FooGenera` that was updated by this mutation."""
+-  fooGenera: FooGenera
++  """The `FooGenus` that was updated by this mutation."""
++  fooGenus: FooGenus
+ 
+   """
+   Our root query field type. Allows us to run any query from our mutation payload.
+   """
+   query: Query
+ 
+-  """An edge for our `FooGenera`. May be used by Relay 1."""
+-  fooGeneraEdge(
+-    """The method to use when ordering `FooGenera`."""
+-    orderBy: [FooGenerasOrderBy!] = PRIMARY_KEY_ASC
+-  ): FooGenerasEdge
++  """An edge for our `FooGenus`. May be used by Relay 1."""
++  fooGenusEdge(
++    """The method to use when ordering `FooGenus`."""
++    orderBy: [FooGeneraOrderBy!] = PRIMARY_KEY_ASC
++  ): FooGeneraEdge
+ }
+ 
+-"""All input for the `updatePondById` mutation."""
+-input UpdatePondByIdInput {
++"""All input for the `updatePondByNodeId` mutation."""
++input UpdatePondByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+@@ -1725,10 +1721,14 @@
+   clientMutationId: String
+ 
+   """
++  The globally unique `ID` which will identify a single `Pond` to be updated.
++  """
++  nodeId: ID!
++
++  """
+   An object where the defined keys will be set on the `Pond` being updated.
+   """
+-  pondPatch: PondPatch!
+-  id: Int!
++  patch: PondPatch!
+ }
+ 
+ """All input for the `updatePond` mutation."""
+@@ -1740,14 +1740,10 @@
+   clientMutationId: String
+ 
+   """
+-  The globally unique `ID` which will identify a single `Pond` to be updated.
+-  """
+-  nodeId: ID!
+-
+-  """
+   An object where the defined keys will be set on the `Pond` being updated.
+   """
+-  pondPatch: PondPatch!
++  patch: PondPatch!
++  id: Int!
+ }
+ 
+ """The output of our update `Pond` mutation."""

--- a/schema.graphql
+++ b/schema.graphql
@@ -764,7 +764,9 @@ enum FishOrderBy {
   PRIMARY_KEY_DESC
 }
 
-"""Represents an update to a `Fish`. Fields that are set will be updated."""
+"""
+Represents an update to a `Fish`. Fields that are set will be updated.
+"""
 input FishPatch {
   id: Int
   pondId: Int
@@ -1143,7 +1145,9 @@ input PondInput {
   name: String!
 }
 
-"""Represents an update to a `Pond`. Fields that are set will be updated."""
+"""
+Represents an update to a `Pond`. Fields that are set will be updated.
+"""
 input PondPatch {
   id: Int
   name: String

--- a/schema.graphql
+++ b/schema.graphql
@@ -9,10 +9,10 @@ type Beverage implements Node {
   name: String!
 
   """Reads a single `Company` that is related to this `Beverage`."""
-  company: Company
+  companyByCompanyId: Company
 
   """Reads a single `Company` that is related to this `Beverage`."""
-  distributor: Company
+  companyByDistributorId: Company
 }
 
 """
@@ -138,7 +138,7 @@ type Company implements Node {
   name: String!
 
   """Reads and enables pagination through a set of `Beverage`."""
-  beverages(
+  beveragesByCompanyId(
     """Only read the first `n` values of the set."""
     first: Int
 
@@ -167,7 +167,7 @@ type Company implements Node {
   ): BeveragesConnection!
 
   """Reads and enables pagination through a set of `Beverage`."""
-  beveragesList(
+  beveragesByCompanyIdList(
     """Only read the first `n` values of the set."""
     first: Int
 
@@ -284,10 +284,10 @@ type CreateBeveragePayload {
   query: Query
 
   """Reads a single `Company` that is related to this `Beverage`."""
-  company: Company
+  companyByCompanyId: Company
 
   """Reads a single `Company` that is related to this `Beverage`."""
-  distributor: Company
+  companyByDistributorId: Company
 
   """An edge for our `Beverage`. May be used by Relay 1."""
   beverageEdge(
@@ -360,7 +360,7 @@ type CreateFishPayload {
   query: Query
 
   """Reads a single `Pond` that is related to this `Fish`."""
-  pond: Pond
+  pondByPondId: Pond
 
   """An edge for our `Fish`. May be used by Relay 1."""
   fishEdge(
@@ -369,39 +369,39 @@ type CreateFishPayload {
   ): FishEdge
 }
 
-"""All input for the create `FooGenus` mutation."""
-input CreateFooGenusInput {
+"""All input for the create `FooGenera` mutation."""
+input CreateFooGeneraInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
   """
   clientMutationId: String
 
-  """The `FooGenus` to be created by this mutation."""
-  fooGenus: FooGenusInput!
+  """The `FooGenera` to be created by this mutation."""
+  fooGenera: FooGeneraInput!
 }
 
-"""The output of our create `FooGenus` mutation."""
-type CreateFooGenusPayload {
+"""The output of our create `FooGenera` mutation."""
+type CreateFooGeneraPayload {
   """
   The exact same `clientMutationId` that was provided in the mutation input,
   unchanged and unused. May be used by a client to track mutations.
   """
   clientMutationId: String
 
-  """The `FooGenus` that was created by this mutation."""
-  fooGenus: FooGenus
+  """The `FooGenera` that was created by this mutation."""
+  fooGenera: FooGenera
 
   """
   Our root query field type. Allows us to run any query from our mutation payload.
   """
   query: Query
 
-  """An edge for our `FooGenus`. May be used by Relay 1."""
-  fooGenusEdge(
-    """The method to use when ordering `FooGenus`."""
-    orderBy: [FooGeneraOrderBy!] = PRIMARY_KEY_ASC
-  ): FooGeneraEdge
+  """An edge for our `FooGenera`. May be used by Relay 1."""
+  fooGeneraEdge(
+    """The method to use when ordering `FooGenera`."""
+    orderBy: [FooGenerasOrderBy!] = PRIMARY_KEY_ASC
+  ): FooGenerasEdge
 }
 
 """All input for the create `Pond` mutation."""
@@ -442,8 +442,18 @@ type CreatePondPayload {
 """A location in a connection that can be used for resuming pagination."""
 scalar Cursor
 
-"""All input for the `deleteBeverageByNodeId` mutation."""
-input DeleteBeverageByNodeIdInput {
+"""All input for the `deleteBeverageById` mutation."""
+input DeleteBeverageByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the `deleteBeverage` mutation."""
+input DeleteBeverageInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -456,16 +466,6 @@ input DeleteBeverageByNodeIdInput {
   nodeId: ID!
 }
 
-"""All input for the `deleteBeverage` mutation."""
-input DeleteBeverageInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-  id: Int!
-}
-
 """The output of our delete `Beverage` mutation."""
 type DeleteBeveragePayload {
   """
@@ -476,7 +476,7 @@ type DeleteBeveragePayload {
 
   """The `Beverage` that was deleted by this mutation."""
   beverage: Beverage
-  deletedBeverageNodeId: ID
+  deletedBeverageId: ID
 
   """
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -484,10 +484,10 @@ type DeleteBeveragePayload {
   query: Query
 
   """Reads a single `Company` that is related to this `Beverage`."""
-  company: Company
+  companyByCompanyId: Company
 
   """Reads a single `Company` that is related to this `Beverage`."""
-  distributor: Company
+  companyByDistributorId: Company
 
   """An edge for our `Beverage`. May be used by Relay 1."""
   beverageEdge(
@@ -496,8 +496,18 @@ type DeleteBeveragePayload {
   ): BeveragesEdge
 }
 
-"""All input for the `deleteCompanyByNodeId` mutation."""
-input DeleteCompanyByNodeIdInput {
+"""All input for the `deleteCompanyById` mutation."""
+input DeleteCompanyByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the `deleteCompany` mutation."""
+input DeleteCompanyInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -510,16 +520,6 @@ input DeleteCompanyByNodeIdInput {
   nodeId: ID!
 }
 
-"""All input for the `deleteCompany` mutation."""
-input DeleteCompanyInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-  id: Int!
-}
-
 """The output of our delete `Company` mutation."""
 type DeleteCompanyPayload {
   """
@@ -530,7 +530,7 @@ type DeleteCompanyPayload {
 
   """The `Company` that was deleted by this mutation."""
   company: Company
-  deletedCompanyNodeId: ID
+  deletedCompanyId: ID
 
   """
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -544,8 +544,18 @@ type DeleteCompanyPayload {
   ): CompaniesEdge
 }
 
-"""All input for the `deleteFishByNodeId` mutation."""
-input DeleteFishByNodeIdInput {
+"""All input for the `deleteFishById` mutation."""
+input DeleteFishByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the `deleteFish` mutation."""
+input DeleteFishInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -558,16 +568,6 @@ input DeleteFishByNodeIdInput {
   nodeId: ID!
 }
 
-"""All input for the `deleteFish` mutation."""
-input DeleteFishInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-  id: Int!
-}
-
 """The output of our delete `Fish` mutation."""
 type DeleteFishPayload {
   """
@@ -578,7 +578,7 @@ type DeleteFishPayload {
 
   """The `Fish` that was deleted by this mutation."""
   fish: Fish
-  deletedFishNodeId: ID
+  deletedFishId: ID
 
   """
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -586,7 +586,7 @@ type DeleteFishPayload {
   query: Query
 
   """Reads a single `Pond` that is related to this `Fish`."""
-  pond: Pond
+  pondByPondId: Pond
 
   """An edge for our `Fish`. May be used by Relay 1."""
   fishEdge(
@@ -595,22 +595,8 @@ type DeleteFishPayload {
   ): FishEdge
 }
 
-"""All input for the `deleteFooGenusByNodeId` mutation."""
-input DeleteFooGenusByNodeIdInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-
-  """
-  The globally unique `ID` which will identify a single `FooGenus` to be deleted.
-  """
-  nodeId: ID!
-}
-
-"""All input for the `deleteFooGenus` mutation."""
-input DeleteFooGenusInput {
+"""All input for the `deleteFooGeneraById` mutation."""
+input DeleteFooGeneraByIdInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -619,32 +605,56 @@ input DeleteFooGenusInput {
   id: Int!
 }
 
-"""The output of our delete `FooGenus` mutation."""
-type DeleteFooGenusPayload {
+"""All input for the `deleteFooGenera` mutation."""
+input DeleteFooGeneraInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `FooGenera` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete `FooGenera` mutation."""
+type DeleteFooGeneraPayload {
   """
   The exact same `clientMutationId` that was provided in the mutation input,
   unchanged and unused. May be used by a client to track mutations.
   """
   clientMutationId: String
 
-  """The `FooGenus` that was deleted by this mutation."""
-  fooGenus: FooGenus
-  deletedFooGenusNodeId: ID
+  """The `FooGenera` that was deleted by this mutation."""
+  fooGenera: FooGenera
+  deletedFooGeneraId: ID
 
   """
   Our root query field type. Allows us to run any query from our mutation payload.
   """
   query: Query
 
-  """An edge for our `FooGenus`. May be used by Relay 1."""
-  fooGenusEdge(
-    """The method to use when ordering `FooGenus`."""
-    orderBy: [FooGeneraOrderBy!] = PRIMARY_KEY_ASC
-  ): FooGeneraEdge
+  """An edge for our `FooGenera`. May be used by Relay 1."""
+  fooGeneraEdge(
+    """The method to use when ordering `FooGenera`."""
+    orderBy: [FooGenerasOrderBy!] = PRIMARY_KEY_ASC
+  ): FooGenerasEdge
 }
 
-"""All input for the `deletePondByNodeId` mutation."""
-input DeletePondByNodeIdInput {
+"""All input for the `deletePondById` mutation."""
+input DeletePondByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the `deletePond` mutation."""
+input DeletePondInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -657,16 +667,6 @@ input DeletePondByNodeIdInput {
   nodeId: ID!
 }
 
-"""All input for the `deletePond` mutation."""
-input DeletePondInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-  id: Int!
-}
-
 """The output of our delete `Pond` mutation."""
 type DeletePondPayload {
   """
@@ -677,7 +677,7 @@ type DeletePondPayload {
 
   """The `Pond` that was deleted by this mutation."""
   pond: Pond
-  deletedPondNodeId: ID
+  deletedPondId: ID
 
   """
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -701,7 +701,7 @@ type Fish implements Node {
   name: String!
 
   """Reads a single `Pond` that is related to this `Fish`."""
-  pond: Pond
+  pondByPondId: Pond
 }
 
 """
@@ -773,44 +773,7 @@ input FishPatch {
   name: String
 }
 
-"""A connection to a list of `FooGenus` values."""
-type FooGeneraConnection {
-  """A list of `FooGenus` objects."""
-  nodes: [FooGenus]!
-
-  """
-  A list of edges which contains the `FooGenus` and cursor to aid in pagination.
-  """
-  edges: [FooGeneraEdge!]!
-
-  """Information to aid in pagination."""
-  pageInfo: PageInfo!
-
-  """The count of *all* `FooGenus` you could get from the connection."""
-  totalCount: Int!
-}
-
-"""A `FooGenus` edge in the connection."""
-type FooGeneraEdge {
-  """A cursor for use in pagination."""
-  cursor: Cursor
-
-  """The `FooGenus` at the end of the edge."""
-  node: FooGenus
-}
-
-"""Methods to use when ordering `FooGenus`."""
-enum FooGeneraOrderBy {
-  NATURAL
-  ID_ASC
-  ID_DESC
-  NAME_ASC
-  NAME_DESC
-  PRIMARY_KEY_ASC
-  PRIMARY_KEY_DESC
-}
-
-type FooGenus implements Node {
+type FooGenera implements Node {
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
@@ -820,10 +783,10 @@ type FooGenus implements Node {
 }
 
 """
-A condition to be used against `FooGenus` object types. All fields are tested
+A condition to be used against `FooGenera` object types. All fields are tested
 for equality and combined with a logical ‘and.’
 """
-input FooGenusCondition {
+input FooGeneraCondition {
   """Checks for equality with the object’s `id` field."""
   id: Int
 
@@ -831,18 +794,55 @@ input FooGenusCondition {
   name: String
 }
 
-"""An input for mutations affecting `FooGenus`"""
-input FooGenusInput {
+"""An input for mutations affecting `FooGenera`"""
+input FooGeneraInput {
   id: Int
   name: String!
 }
 
 """
-Represents an update to a `FooGenus`. Fields that are set will be updated.
+Represents an update to a `FooGenera`. Fields that are set will be updated.
 """
-input FooGenusPatch {
+input FooGeneraPatch {
   id: Int
   name: String
+}
+
+"""A connection to a list of `FooGenera` values."""
+type FooGenerasConnection {
+  """A list of `FooGenera` objects."""
+  nodes: [FooGenera]!
+
+  """
+  A list of edges which contains the `FooGenera` and cursor to aid in pagination.
+  """
+  edges: [FooGenerasEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `FooGenera` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `FooGenera` edge in the connection."""
+type FooGenerasEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `FooGenera` at the end of the edge."""
+  node: FooGenera
+}
+
+"""Methods to use when ordering `FooGenera`."""
+enum FooGenerasOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
 }
 
 """
@@ -873,13 +873,13 @@ type Mutation {
     input: CreateFishInput!
   ): CreateFishPayload
 
-  """Creates a single `FooGenus`."""
-  createFooGenus(
+  """Creates a single `FooGenera`."""
+  createFooGenera(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: CreateFooGenusInput!
-  ): CreateFooGenusPayload
+    input: CreateFooGeneraInput!
+  ): CreateFooGeneraPayload
 
   """Creates a single `Pond`."""
   createPond(
@@ -890,14 +890,6 @@ type Mutation {
   ): CreatePondPayload
 
   """Updates a single `Beverage` using its globally unique id and a patch."""
-  updateBeverageByNodeId(
-    """
-    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    """
-    input: UpdateBeverageByNodeIdInput!
-  ): UpdateBeveragePayload
-
-  """Updates a single `Beverage` using a unique key and a patch."""
   updateBeverage(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -905,15 +897,15 @@ type Mutation {
     input: UpdateBeverageInput!
   ): UpdateBeveragePayload
 
-  """Updates a single `Company` using its globally unique id and a patch."""
-  updateCompanyByNodeId(
+  """Updates a single `Beverage` using a unique key and a patch."""
+  updateBeverageById(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: UpdateCompanyByNodeIdInput!
-  ): UpdateCompanyPayload
+    input: UpdateBeverageByIdInput!
+  ): UpdateBeveragePayload
 
-  """Updates a single `Company` using a unique key and a patch."""
+  """Updates a single `Company` using its globally unique id and a patch."""
   updateCompany(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -921,15 +913,15 @@ type Mutation {
     input: UpdateCompanyInput!
   ): UpdateCompanyPayload
 
-  """Updates a single `Fish` using its globally unique id and a patch."""
-  updateFishByNodeId(
+  """Updates a single `Company` using a unique key and a patch."""
+  updateCompanyById(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: UpdateFishByNodeIdInput!
-  ): UpdateFishPayload
+    input: UpdateCompanyByIdInput!
+  ): UpdateCompanyPayload
 
-  """Updates a single `Fish` using a unique key and a patch."""
+  """Updates a single `Fish` using its globally unique id and a patch."""
   updateFish(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -937,31 +929,33 @@ type Mutation {
     input: UpdateFishInput!
   ): UpdateFishPayload
 
-  """Updates a single `FooGenus` using its globally unique id and a patch."""
-  updateFooGenusByNodeId(
+  """Updates a single `Fish` using a unique key and a patch."""
+  updateFishById(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: UpdateFooGenusByNodeIdInput!
-  ): UpdateFooGenusPayload
+    input: UpdateFishByIdInput!
+  ): UpdateFishPayload
 
-  """Updates a single `FooGenus` using a unique key and a patch."""
-  updateFooGenus(
+  """
+  Updates a single `FooGenera` using its globally unique id and a patch.
+  """
+  updateFooGenera(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: UpdateFooGenusInput!
-  ): UpdateFooGenusPayload
+    input: UpdateFooGeneraInput!
+  ): UpdateFooGeneraPayload
+
+  """Updates a single `FooGenera` using a unique key and a patch."""
+  updateFooGeneraById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateFooGeneraByIdInput!
+  ): UpdateFooGeneraPayload
 
   """Updates a single `Pond` using its globally unique id and a patch."""
-  updatePondByNodeId(
-    """
-    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    """
-    input: UpdatePondByNodeIdInput!
-  ): UpdatePondPayload
-
-  """Updates a single `Pond` using a unique key and a patch."""
   updatePond(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -969,15 +963,15 @@ type Mutation {
     input: UpdatePondInput!
   ): UpdatePondPayload
 
-  """Deletes a single `Beverage` using its globally unique id."""
-  deleteBeverageByNodeId(
+  """Updates a single `Pond` using a unique key and a patch."""
+  updatePondById(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: DeleteBeverageByNodeIdInput!
-  ): DeleteBeveragePayload
+    input: UpdatePondByIdInput!
+  ): UpdatePondPayload
 
-  """Deletes a single `Beverage` using a unique key."""
+  """Deletes a single `Beverage` using its globally unique id."""
   deleteBeverage(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -985,15 +979,15 @@ type Mutation {
     input: DeleteBeverageInput!
   ): DeleteBeveragePayload
 
-  """Deletes a single `Company` using its globally unique id."""
-  deleteCompanyByNodeId(
+  """Deletes a single `Beverage` using a unique key."""
+  deleteBeverageById(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: DeleteCompanyByNodeIdInput!
-  ): DeleteCompanyPayload
+    input: DeleteBeverageByIdInput!
+  ): DeleteBeveragePayload
 
-  """Deletes a single `Company` using a unique key."""
+  """Deletes a single `Company` using its globally unique id."""
   deleteCompany(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -1001,15 +995,15 @@ type Mutation {
     input: DeleteCompanyInput!
   ): DeleteCompanyPayload
 
-  """Deletes a single `Fish` using its globally unique id."""
-  deleteFishByNodeId(
+  """Deletes a single `Company` using a unique key."""
+  deleteCompanyById(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: DeleteFishByNodeIdInput!
-  ): DeleteFishPayload
+    input: DeleteCompanyByIdInput!
+  ): DeleteCompanyPayload
 
-  """Deletes a single `Fish` using a unique key."""
+  """Deletes a single `Fish` using its globally unique id."""
   deleteFish(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -1017,36 +1011,44 @@ type Mutation {
     input: DeleteFishInput!
   ): DeleteFishPayload
 
-  """Deletes a single `FooGenus` using its globally unique id."""
-  deleteFooGenusByNodeId(
+  """Deletes a single `Fish` using a unique key."""
+  deleteFishById(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: DeleteFooGenusByNodeIdInput!
-  ): DeleteFooGenusPayload
+    input: DeleteFishByIdInput!
+  ): DeleteFishPayload
 
-  """Deletes a single `FooGenus` using a unique key."""
-  deleteFooGenus(
+  """Deletes a single `FooGenera` using its globally unique id."""
+  deleteFooGenera(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: DeleteFooGenusInput!
-  ): DeleteFooGenusPayload
+    input: DeleteFooGeneraInput!
+  ): DeleteFooGeneraPayload
+
+  """Deletes a single `FooGenera` using a unique key."""
+  deleteFooGeneraById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteFooGeneraByIdInput!
+  ): DeleteFooGeneraPayload
 
   """Deletes a single `Pond` using its globally unique id."""
-  deletePondByNodeId(
-    """
-    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    """
-    input: DeletePondByNodeIdInput!
-  ): DeletePondPayload
-
-  """Deletes a single `Pond` using a unique key."""
   deletePond(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
     input: DeletePondInput!
+  ): DeletePondPayload
+
+  """Deletes a single `Pond` using a unique key."""
+  deletePondById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeletePondByIdInput!
   ): DeletePondPayload
 }
 
@@ -1082,7 +1084,7 @@ type Pond implements Node {
   name: String!
 
   """Reads and enables pagination through a set of `Fish`."""
-  fishes(
+  fishByPondId(
     """Only read the first `n` values of the set."""
     first: Int
 
@@ -1111,7 +1113,7 @@ type Pond implements Node {
   ): FishConnection!
 
   """Reads and enables pagination through a set of `Fish`."""
-  fishesList(
+  fishByPondIdList(
     """Only read the first `n` values of the set."""
     first: Int
 
@@ -1210,7 +1212,7 @@ type Query implements Node {
   ): Node
 
   """Reads and enables pagination through a set of `Beverage`."""
-  beverages(
+  allBeverages(
     """Only read the first `n` values of the set."""
     first: Int
 
@@ -1239,7 +1241,7 @@ type Query implements Node {
   ): BeveragesConnection
 
   """Reads a set of `Beverage`."""
-  beveragesList(
+  allBeveragesList(
     """Only read the first `n` values of the set."""
     first: Int
 
@@ -1256,7 +1258,7 @@ type Query implements Node {
   ): [Beverage!]
 
   """Reads and enables pagination through a set of `Company`."""
-  companies(
+  allCompanies(
     """Only read the first `n` values of the set."""
     first: Int
 
@@ -1285,7 +1287,7 @@ type Query implements Node {
   ): CompaniesConnection
 
   """Reads a set of `Company`."""
-  companiesList(
+  allCompaniesList(
     """Only read the first `n` values of the set."""
     first: Int
 
@@ -1302,7 +1304,7 @@ type Query implements Node {
   ): [Company!]
 
   """Reads and enables pagination through a set of `Fish`."""
-  fishes(
+  allFish(
     """Only read the first `n` values of the set."""
     first: Int
 
@@ -1331,7 +1333,7 @@ type Query implements Node {
   ): FishConnection
 
   """Reads a set of `Fish`."""
-  fishesList(
+  allFishList(
     """Only read the first `n` values of the set."""
     first: Int
 
@@ -1347,8 +1349,8 @@ type Query implements Node {
     condition: FishCondition
   ): [Fish!]
 
-  """Reads and enables pagination through a set of `FooGenus`."""
-  fooGenera(
+  """Reads and enables pagination through a set of `FooGenera`."""
+  allFooGeneras(
     """Only read the first `n` values of the set."""
     first: Int
 
@@ -1367,34 +1369,34 @@ type Query implements Node {
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering `FooGenus`."""
-    orderBy: [FooGeneraOrderBy!] = [PRIMARY_KEY_ASC]
+    """The method to use when ordering `FooGenera`."""
+    orderBy: [FooGenerasOrderBy!] = [PRIMARY_KEY_ASC]
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: FooGenusCondition
-  ): FooGeneraConnection
+    condition: FooGeneraCondition
+  ): FooGenerasConnection
 
-  """Reads a set of `FooGenus`."""
-  fooGeneraList(
+  """Reads a set of `FooGenera`."""
+  allFooGenerasList(
     """Only read the first `n` values of the set."""
     first: Int
 
     """Skip the first `n` values."""
     offset: Int
 
-    """The method to use when ordering `FooGenus`."""
-    orderBy: [FooGeneraOrderBy!]
+    """The method to use when ordering `FooGenera`."""
+    orderBy: [FooGenerasOrderBy!]
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: FooGenusCondition
-  ): [FooGenus!]
+    condition: FooGeneraCondition
+  ): [FooGenera!]
 
   """Reads and enables pagination through a set of `Pond`."""
-  ponds(
+  allPonds(
     """Only read the first `n` values of the set."""
     first: Int
 
@@ -1423,7 +1425,7 @@ type Query implements Node {
   ): PondsConnection
 
   """Reads a set of `Pond`."""
-  pondsList(
+  allPondsList(
     """Only read the first `n` values of the set."""
     first: Int
 
@@ -1438,45 +1440,62 @@ type Query implements Node {
     """
     condition: PondCondition
   ): [Pond!]
-  beverage(id: Int!): Beverage
-  company(id: Int!): Company
-  fish(id: Int!): Fish
-  fooGenus(id: Int!): FooGenus
-  pond(id: Int!): Pond
+  beverageById(id: Int!): Beverage
+  companyById(id: Int!): Company
+  fishById(id: Int!): Fish
+  fooGeneraById(id: Int!): FooGenera
+  pondById(id: Int!): Pond
 
   """Reads a single `Beverage` using its globally unique `ID`."""
-  beverageByNodeId(
+  beverage(
     """The globally unique `ID` to be used in selecting a single `Beverage`."""
     nodeId: ID!
   ): Beverage
 
   """Reads a single `Company` using its globally unique `ID`."""
-  companyByNodeId(
+  company(
     """The globally unique `ID` to be used in selecting a single `Company`."""
     nodeId: ID!
   ): Company
 
   """Reads a single `Fish` using its globally unique `ID`."""
-  fishByNodeId(
+  fish(
     """The globally unique `ID` to be used in selecting a single `Fish`."""
     nodeId: ID!
   ): Fish
 
-  """Reads a single `FooGenus` using its globally unique `ID`."""
-  fooGenusByNodeId(
-    """The globally unique `ID` to be used in selecting a single `FooGenus`."""
+  """Reads a single `FooGenera` using its globally unique `ID`."""
+  fooGenera(
+    """
+    The globally unique `ID` to be used in selecting a single `FooGenera`.
+    """
     nodeId: ID!
-  ): FooGenus
+  ): FooGenera
 
   """Reads a single `Pond` using its globally unique `ID`."""
-  pondByNodeId(
+  pond(
     """The globally unique `ID` to be used in selecting a single `Pond`."""
     nodeId: ID!
   ): Pond
 }
 
-"""All input for the `updateBeverageByNodeId` mutation."""
-input UpdateBeverageByNodeIdInput {
+"""All input for the `updateBeverageById` mutation."""
+input UpdateBeverageByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Beverage` being updated.
+  """
+  beveragePatch: BeveragePatch!
+  id: Int!
+}
+
+"""All input for the `updateBeverage` mutation."""
+input UpdateBeverageInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -1491,22 +1510,7 @@ input UpdateBeverageByNodeIdInput {
   """
   An object where the defined keys will be set on the `Beverage` being updated.
   """
-  patch: BeveragePatch!
-}
-
-"""All input for the `updateBeverage` mutation."""
-input UpdateBeverageInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-
-  """
-  An object where the defined keys will be set on the `Beverage` being updated.
-  """
-  patch: BeveragePatch!
-  id: Int!
+  beveragePatch: BeveragePatch!
 }
 
 """The output of our update `Beverage` mutation."""
@@ -1526,10 +1530,10 @@ type UpdateBeveragePayload {
   query: Query
 
   """Reads a single `Company` that is related to this `Beverage`."""
-  company: Company
+  companyByCompanyId: Company
 
   """Reads a single `Company` that is related to this `Beverage`."""
-  distributor: Company
+  companyByDistributorId: Company
 
   """An edge for our `Beverage`. May be used by Relay 1."""
   beverageEdge(
@@ -1538,8 +1542,23 @@ type UpdateBeveragePayload {
   ): BeveragesEdge
 }
 
-"""All input for the `updateCompanyByNodeId` mutation."""
-input UpdateCompanyByNodeIdInput {
+"""All input for the `updateCompanyById` mutation."""
+input UpdateCompanyByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Company` being updated.
+  """
+  companyPatch: CompanyPatch!
+  id: Int!
+}
+
+"""All input for the `updateCompany` mutation."""
+input UpdateCompanyInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -1554,22 +1573,7 @@ input UpdateCompanyByNodeIdInput {
   """
   An object where the defined keys will be set on the `Company` being updated.
   """
-  patch: CompanyPatch!
-}
-
-"""All input for the `updateCompany` mutation."""
-input UpdateCompanyInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-
-  """
-  An object where the defined keys will be set on the `Company` being updated.
-  """
-  patch: CompanyPatch!
-  id: Int!
+  companyPatch: CompanyPatch!
 }
 
 """The output of our update `Company` mutation."""
@@ -1595,8 +1599,23 @@ type UpdateCompanyPayload {
   ): CompaniesEdge
 }
 
-"""All input for the `updateFishByNodeId` mutation."""
-input UpdateFishByNodeIdInput {
+"""All input for the `updateFishById` mutation."""
+input UpdateFishByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Fish` being updated.
+  """
+  fishPatch: FishPatch!
+  id: Int!
+}
+
+"""All input for the `updateFish` mutation."""
+input UpdateFishInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -1611,22 +1630,7 @@ input UpdateFishByNodeIdInput {
   """
   An object where the defined keys will be set on the `Fish` being updated.
   """
-  patch: FishPatch!
-}
-
-"""All input for the `updateFish` mutation."""
-input UpdateFishInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-
-  """
-  An object where the defined keys will be set on the `Fish` being updated.
-  """
-  patch: FishPatch!
-  id: Int!
+  fishPatch: FishPatch!
 }
 
 """The output of our update `Fish` mutation."""
@@ -1646,7 +1650,7 @@ type UpdateFishPayload {
   query: Query
 
   """Reads a single `Pond` that is related to this `Fish`."""
-  pond: Pond
+  pondByPondId: Pond
 
   """An edge for our `Fish`. May be used by Relay 1."""
   fishEdge(
@@ -1655,8 +1659,8 @@ type UpdateFishPayload {
   ): FishEdge
 }
 
-"""All input for the `updateFooGenusByNodeId` mutation."""
-input UpdateFooGenusByNodeIdInput {
+"""All input for the `updateFooGeneraById` mutation."""
+input UpdateFooGeneraByIdInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -1664,56 +1668,71 @@ input UpdateFooGenusByNodeIdInput {
   clientMutationId: String
 
   """
-  The globally unique `ID` which will identify a single `FooGenus` to be updated.
+  An object where the defined keys will be set on the `FooGenera` being updated.
+  """
+  fooGeneraPatch: FooGeneraPatch!
+  id: Int!
+}
+
+"""All input for the `updateFooGenera` mutation."""
+input UpdateFooGeneraInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `FooGenera` to be updated.
   """
   nodeId: ID!
 
   """
-  An object where the defined keys will be set on the `FooGenus` being updated.
+  An object where the defined keys will be set on the `FooGenera` being updated.
   """
-  patch: FooGenusPatch!
+  fooGeneraPatch: FooGeneraPatch!
 }
 
-"""All input for the `updateFooGenus` mutation."""
-input UpdateFooGenusInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-
-  """
-  An object where the defined keys will be set on the `FooGenus` being updated.
-  """
-  patch: FooGenusPatch!
-  id: Int!
-}
-
-"""The output of our update `FooGenus` mutation."""
-type UpdateFooGenusPayload {
+"""The output of our update `FooGenera` mutation."""
+type UpdateFooGeneraPayload {
   """
   The exact same `clientMutationId` that was provided in the mutation input,
   unchanged and unused. May be used by a client to track mutations.
   """
   clientMutationId: String
 
-  """The `FooGenus` that was updated by this mutation."""
-  fooGenus: FooGenus
+  """The `FooGenera` that was updated by this mutation."""
+  fooGenera: FooGenera
 
   """
   Our root query field type. Allows us to run any query from our mutation payload.
   """
   query: Query
 
-  """An edge for our `FooGenus`. May be used by Relay 1."""
-  fooGenusEdge(
-    """The method to use when ordering `FooGenus`."""
-    orderBy: [FooGeneraOrderBy!] = PRIMARY_KEY_ASC
-  ): FooGeneraEdge
+  """An edge for our `FooGenera`. May be used by Relay 1."""
+  fooGeneraEdge(
+    """The method to use when ordering `FooGenera`."""
+    orderBy: [FooGenerasOrderBy!] = PRIMARY_KEY_ASC
+  ): FooGenerasEdge
 }
 
-"""All input for the `updatePondByNodeId` mutation."""
-input UpdatePondByNodeIdInput {
+"""All input for the `updatePondById` mutation."""
+input UpdatePondByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Pond` being updated.
+  """
+  pondPatch: PondPatch!
+  id: Int!
+}
+
+"""All input for the `updatePond` mutation."""
+input UpdatePondInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -1728,22 +1747,7 @@ input UpdatePondByNodeIdInput {
   """
   An object where the defined keys will be set on the `Pond` being updated.
   """
-  patch: PondPatch!
-}
-
-"""All input for the `updatePond` mutation."""
-input UpdatePondInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-
-  """
-  An object where the defined keys will be set on the `Pond` being updated.
-  """
-  patch: PondPatch!
-  id: Int!
+  pondPatch: PondPatch!
 }
 
 """The output of our update `Pond` mutation."""

--- a/schema.graphql
+++ b/schema.graphql
@@ -65,7 +65,7 @@ type BeveragesConnection {
   pageInfo: PageInfo!
 
   """The count of *all* `Beverage` you could get from the connection."""
-  totalCount: Int
+  totalCount: Int!
 }
 
 """A `Beverage` edge in the connection."""
@@ -106,7 +106,7 @@ type CompaniesConnection {
   pageInfo: PageInfo!
 
   """The count of *all* `Company` you could get from the connection."""
-  totalCount: Int
+  totalCount: Int!
 }
 
 """A `Company` edge in the connection."""
@@ -369,6 +369,41 @@ type CreateFishPayload {
   ): FishEdge
 }
 
+"""All input for the create `FooGenus` mutation."""
+input CreateFooGenusInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `FooGenus` to be created by this mutation."""
+  fooGenus: FooGenusInput!
+}
+
+"""The output of our create `FooGenus` mutation."""
+type CreateFooGenusPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `FooGenus` that was created by this mutation."""
+  fooGenus: FooGenus
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `FooGenus`. May be used by Relay 1."""
+  fooGenusEdge(
+    """The method to use when ordering `FooGenus`."""
+    orderBy: [FooGeneraOrderBy!] = PRIMARY_KEY_ASC
+  ): FooGeneraEdge
+}
+
 """All input for the create `Pond` mutation."""
 input CreatePondInput {
   """
@@ -407,18 +442,8 @@ type CreatePondPayload {
 """A location in a connection that can be used for resuming pagination."""
 scalar Cursor
 
-"""All input for the `deleteBeverageById` mutation."""
-input DeleteBeverageByIdInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-  id: Int!
-}
-
-"""All input for the `deleteBeverage` mutation."""
-input DeleteBeverageInput {
+"""All input for the `deleteBeverageByNodeId` mutation."""
+input DeleteBeverageByNodeIdInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -431,6 +456,16 @@ input DeleteBeverageInput {
   nodeId: ID!
 }
 
+"""All input for the `deleteBeverage` mutation."""
+input DeleteBeverageInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
 """The output of our delete `Beverage` mutation."""
 type DeleteBeveragePayload {
   """
@@ -441,7 +476,7 @@ type DeleteBeveragePayload {
 
   """The `Beverage` that was deleted by this mutation."""
   beverage: Beverage
-  deletedBeverageId: ID
+  deletedBeverageNodeId: ID
 
   """
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -461,18 +496,8 @@ type DeleteBeveragePayload {
   ): BeveragesEdge
 }
 
-"""All input for the `deleteCompanyById` mutation."""
-input DeleteCompanyByIdInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-  id: Int!
-}
-
-"""All input for the `deleteCompany` mutation."""
-input DeleteCompanyInput {
+"""All input for the `deleteCompanyByNodeId` mutation."""
+input DeleteCompanyByNodeIdInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -485,6 +510,16 @@ input DeleteCompanyInput {
   nodeId: ID!
 }
 
+"""All input for the `deleteCompany` mutation."""
+input DeleteCompanyInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
 """The output of our delete `Company` mutation."""
 type DeleteCompanyPayload {
   """
@@ -495,7 +530,7 @@ type DeleteCompanyPayload {
 
   """The `Company` that was deleted by this mutation."""
   company: Company
-  deletedCompanyId: ID
+  deletedCompanyNodeId: ID
 
   """
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -509,18 +544,8 @@ type DeleteCompanyPayload {
   ): CompaniesEdge
 }
 
-"""All input for the `deleteFishById` mutation."""
-input DeleteFishByIdInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-  id: Int!
-}
-
-"""All input for the `deleteFish` mutation."""
-input DeleteFishInput {
+"""All input for the `deleteFishByNodeId` mutation."""
+input DeleteFishByNodeIdInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -533,6 +558,16 @@ input DeleteFishInput {
   nodeId: ID!
 }
 
+"""All input for the `deleteFish` mutation."""
+input DeleteFishInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
 """The output of our delete `Fish` mutation."""
 type DeleteFishPayload {
   """
@@ -543,7 +578,7 @@ type DeleteFishPayload {
 
   """The `Fish` that was deleted by this mutation."""
   fish: Fish
-  deletedFishId: ID
+  deletedFishNodeId: ID
 
   """
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -560,8 +595,22 @@ type DeleteFishPayload {
   ): FishEdge
 }
 
-"""All input for the `deletePondById` mutation."""
-input DeletePondByIdInput {
+"""All input for the `deleteFooGenusByNodeId` mutation."""
+input DeleteFooGenusByNodeIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `FooGenus` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""All input for the `deleteFooGenus` mutation."""
+input DeleteFooGenusInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -570,8 +619,32 @@ input DeletePondByIdInput {
   id: Int!
 }
 
-"""All input for the `deletePond` mutation."""
-input DeletePondInput {
+"""The output of our delete `FooGenus` mutation."""
+type DeleteFooGenusPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `FooGenus` that was deleted by this mutation."""
+  fooGenus: FooGenus
+  deletedFooGenusNodeId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `FooGenus`. May be used by Relay 1."""
+  fooGenusEdge(
+    """The method to use when ordering `FooGenus`."""
+    orderBy: [FooGeneraOrderBy!] = PRIMARY_KEY_ASC
+  ): FooGeneraEdge
+}
+
+"""All input for the `deletePondByNodeId` mutation."""
+input DeletePondByNodeIdInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -584,6 +657,16 @@ input DeletePondInput {
   nodeId: ID!
 }
 
+"""All input for the `deletePond` mutation."""
+input DeletePondInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
 """The output of our delete `Pond` mutation."""
 type DeletePondPayload {
   """
@@ -594,7 +677,7 @@ type DeletePondPayload {
 
   """The `Pond` that was deleted by this mutation."""
   pond: Pond
-  deletedPondId: ID
+  deletedPondNodeId: ID
 
   """
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -649,7 +732,7 @@ type FishConnection {
   pageInfo: PageInfo!
 
   """The count of *all* `Fish` you could get from the connection."""
-  totalCount: Int
+  totalCount: Int!
 }
 
 """A `Fish` edge in the connection."""
@@ -681,12 +764,82 @@ enum FishOrderBy {
   PRIMARY_KEY_DESC
 }
 
-"""
-Represents an update to a `Fish`. Fields that are set will be updated.
-"""
+"""Represents an update to a `Fish`. Fields that are set will be updated."""
 input FishPatch {
   id: Int
   pondId: Int
+  name: String
+}
+
+"""A connection to a list of `FooGenus` values."""
+type FooGeneraConnection {
+  """A list of `FooGenus` objects."""
+  nodes: [FooGenus]!
+
+  """
+  A list of edges which contains the `FooGenus` and cursor to aid in pagination.
+  """
+  edges: [FooGeneraEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `FooGenus` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `FooGenus` edge in the connection."""
+type FooGeneraEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `FooGenus` at the end of the edge."""
+  node: FooGenus
+}
+
+"""Methods to use when ordering `FooGenus`."""
+enum FooGeneraOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+type FooGenus implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  name: String!
+}
+
+"""
+A condition to be used against `FooGenus` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input FooGenusCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `name` field."""
+  name: String
+}
+
+"""An input for mutations affecting `FooGenus`"""
+input FooGenusInput {
+  id: Int
+  name: String!
+}
+
+"""
+Represents an update to a `FooGenus`. Fields that are set will be updated.
+"""
+input FooGenusPatch {
+  id: Int
   name: String
 }
 
@@ -718,6 +871,14 @@ type Mutation {
     input: CreateFishInput!
   ): CreateFishPayload
 
+  """Creates a single `FooGenus`."""
+  createFooGenus(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateFooGenusInput!
+  ): CreateFooGenusPayload
+
   """Creates a single `Pond`."""
   createPond(
     """
@@ -727,6 +888,14 @@ type Mutation {
   ): CreatePondPayload
 
   """Updates a single `Beverage` using its globally unique id and a patch."""
+  updateBeverageByNodeId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateBeverageByNodeIdInput!
+  ): UpdateBeveragePayload
+
+  """Updates a single `Beverage` using a unique key and a patch."""
   updateBeverage(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -734,15 +903,15 @@ type Mutation {
     input: UpdateBeverageInput!
   ): UpdateBeveragePayload
 
-  """Updates a single `Beverage` using a unique key and a patch."""
-  updateBeverageById(
+  """Updates a single `Company` using its globally unique id and a patch."""
+  updateCompanyByNodeId(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: UpdateBeverageByIdInput!
-  ): UpdateBeveragePayload
+    input: UpdateCompanyByNodeIdInput!
+  ): UpdateCompanyPayload
 
-  """Updates a single `Company` using its globally unique id and a patch."""
+  """Updates a single `Company` using a unique key and a patch."""
   updateCompany(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -750,15 +919,15 @@ type Mutation {
     input: UpdateCompanyInput!
   ): UpdateCompanyPayload
 
-  """Updates a single `Company` using a unique key and a patch."""
-  updateCompanyById(
+  """Updates a single `Fish` using its globally unique id and a patch."""
+  updateFishByNodeId(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: UpdateCompanyByIdInput!
-  ): UpdateCompanyPayload
+    input: UpdateFishByNodeIdInput!
+  ): UpdateFishPayload
 
-  """Updates a single `Fish` using its globally unique id and a patch."""
+  """Updates a single `Fish` using a unique key and a patch."""
   updateFish(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -766,15 +935,31 @@ type Mutation {
     input: UpdateFishInput!
   ): UpdateFishPayload
 
-  """Updates a single `Fish` using a unique key and a patch."""
-  updateFishById(
+  """Updates a single `FooGenus` using its globally unique id and a patch."""
+  updateFooGenusByNodeId(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: UpdateFishByIdInput!
-  ): UpdateFishPayload
+    input: UpdateFooGenusByNodeIdInput!
+  ): UpdateFooGenusPayload
+
+  """Updates a single `FooGenus` using a unique key and a patch."""
+  updateFooGenus(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateFooGenusInput!
+  ): UpdateFooGenusPayload
 
   """Updates a single `Pond` using its globally unique id and a patch."""
+  updatePondByNodeId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdatePondByNodeIdInput!
+  ): UpdatePondPayload
+
+  """Updates a single `Pond` using a unique key and a patch."""
   updatePond(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -782,15 +967,15 @@ type Mutation {
     input: UpdatePondInput!
   ): UpdatePondPayload
 
-  """Updates a single `Pond` using a unique key and a patch."""
-  updatePondById(
+  """Deletes a single `Beverage` using its globally unique id."""
+  deleteBeverageByNodeId(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: UpdatePondByIdInput!
-  ): UpdatePondPayload
+    input: DeleteBeverageByNodeIdInput!
+  ): DeleteBeveragePayload
 
-  """Deletes a single `Beverage` using its globally unique id."""
+  """Deletes a single `Beverage` using a unique key."""
   deleteBeverage(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -798,15 +983,15 @@ type Mutation {
     input: DeleteBeverageInput!
   ): DeleteBeveragePayload
 
-  """Deletes a single `Beverage` using a unique key."""
-  deleteBeverageById(
+  """Deletes a single `Company` using its globally unique id."""
+  deleteCompanyByNodeId(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: DeleteBeverageByIdInput!
-  ): DeleteBeveragePayload
+    input: DeleteCompanyByNodeIdInput!
+  ): DeleteCompanyPayload
 
-  """Deletes a single `Company` using its globally unique id."""
+  """Deletes a single `Company` using a unique key."""
   deleteCompany(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -814,15 +999,15 @@ type Mutation {
     input: DeleteCompanyInput!
   ): DeleteCompanyPayload
 
-  """Deletes a single `Company` using a unique key."""
-  deleteCompanyById(
+  """Deletes a single `Fish` using its globally unique id."""
+  deleteFishByNodeId(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: DeleteCompanyByIdInput!
-  ): DeleteCompanyPayload
+    input: DeleteFishByNodeIdInput!
+  ): DeleteFishPayload
 
-  """Deletes a single `Fish` using its globally unique id."""
+  """Deletes a single `Fish` using a unique key."""
   deleteFish(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -830,28 +1015,36 @@ type Mutation {
     input: DeleteFishInput!
   ): DeleteFishPayload
 
-  """Deletes a single `Fish` using a unique key."""
-  deleteFishById(
+  """Deletes a single `FooGenus` using its globally unique id."""
+  deleteFooGenusByNodeId(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: DeleteFishByIdInput!
-  ): DeleteFishPayload
+    input: DeleteFooGenusByNodeIdInput!
+  ): DeleteFooGenusPayload
+
+  """Deletes a single `FooGenus` using a unique key."""
+  deleteFooGenus(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteFooGenusInput!
+  ): DeleteFooGenusPayload
 
   """Deletes a single `Pond` using its globally unique id."""
+  deletePondByNodeId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeletePondByNodeIdInput!
+  ): DeletePondPayload
+
+  """Deletes a single `Pond` using a unique key."""
   deletePond(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
     input: DeletePondInput!
-  ): DeletePondPayload
-
-  """Deletes a single `Pond` using a unique key."""
-  deletePondById(
-    """
-    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    """
-    input: DeletePondByIdInput!
   ): DeletePondPayload
 }
 
@@ -950,9 +1143,7 @@ input PondInput {
   name: String!
 }
 
-"""
-Represents an update to a `Pond`. Fields that are set will be updated.
-"""
+"""Represents an update to a `Pond`. Fields that are set will be updated."""
 input PondPatch {
   id: Int
   name: String
@@ -972,7 +1163,7 @@ type PondsConnection {
   pageInfo: PageInfo!
 
   """The count of *all* `Pond` you could get from the connection."""
-  totalCount: Int
+  totalCount: Int!
 }
 
 """A `Pond` edge in the connection."""
@@ -1152,6 +1343,52 @@ type Query implements Node {
     condition: FishCondition
   ): [Fish!]
 
+  """Reads and enables pagination through a set of `FooGenus`."""
+  fooGenera(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `FooGenus`."""
+    orderBy: [FooGeneraOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: FooGenusCondition
+  ): FooGeneraConnection
+
+  """Reads a set of `FooGenus`."""
+  fooGeneraList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `FooGenus`."""
+    orderBy: [FooGeneraOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: FooGenusCondition
+  ): [FooGenus!]
+
   """Reads and enables pagination through a set of `Pond`."""
   ponds(
     """Only read the first `n` values of the set."""
@@ -1197,53 +1434,45 @@ type Query implements Node {
     """
     condition: PondCondition
   ): [Pond!]
-  beverageById(id: Int!): Beverage
-  companyById(id: Int!): Company
-  fishById(id: Int!): Fish
-  pondById(id: Int!): Pond
+  beverage(id: Int!): Beverage
+  company(id: Int!): Company
+  fish(id: Int!): Fish
+  fooGenus(id: Int!): FooGenus
+  pond(id: Int!): Pond
 
   """Reads a single `Beverage` using its globally unique `ID`."""
-  beverage(
+  beverageByNodeId(
     """The globally unique `ID` to be used in selecting a single `Beverage`."""
     nodeId: ID!
   ): Beverage
 
   """Reads a single `Company` using its globally unique `ID`."""
-  company(
+  companyByNodeId(
     """The globally unique `ID` to be used in selecting a single `Company`."""
     nodeId: ID!
   ): Company
 
   """Reads a single `Fish` using its globally unique `ID`."""
-  fish(
+  fishByNodeId(
     """The globally unique `ID` to be used in selecting a single `Fish`."""
     nodeId: ID!
   ): Fish
 
+  """Reads a single `FooGenus` using its globally unique `ID`."""
+  fooGenusByNodeId(
+    """The globally unique `ID` to be used in selecting a single `FooGenus`."""
+    nodeId: ID!
+  ): FooGenus
+
   """Reads a single `Pond` using its globally unique `ID`."""
-  pond(
+  pondByNodeId(
     """The globally unique `ID` to be used in selecting a single `Pond`."""
     nodeId: ID!
   ): Pond
 }
 
-"""All input for the `updateBeverageById` mutation."""
-input UpdateBeverageByIdInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-
-  """
-  An object where the defined keys will be set on the `Beverage` being updated.
-  """
-  patch: BeveragePatch!
-  id: Int!
-}
-
-"""All input for the `updateBeverage` mutation."""
-input UpdateBeverageInput {
+"""All input for the `updateBeverageByNodeId` mutation."""
+input UpdateBeverageByNodeIdInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -1259,6 +1488,21 @@ input UpdateBeverageInput {
   An object where the defined keys will be set on the `Beverage` being updated.
   """
   patch: BeveragePatch!
+}
+
+"""All input for the `updateBeverage` mutation."""
+input UpdateBeverageInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Beverage` being updated.
+  """
+  patch: BeveragePatch!
+  id: Int!
 }
 
 """The output of our update `Beverage` mutation."""
@@ -1290,23 +1534,8 @@ type UpdateBeveragePayload {
   ): BeveragesEdge
 }
 
-"""All input for the `updateCompanyById` mutation."""
-input UpdateCompanyByIdInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-
-  """
-  An object where the defined keys will be set on the `Company` being updated.
-  """
-  patch: CompanyPatch!
-  id: Int!
-}
-
-"""All input for the `updateCompany` mutation."""
-input UpdateCompanyInput {
+"""All input for the `updateCompanyByNodeId` mutation."""
+input UpdateCompanyByNodeIdInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -1322,6 +1551,21 @@ input UpdateCompanyInput {
   An object where the defined keys will be set on the `Company` being updated.
   """
   patch: CompanyPatch!
+}
+
+"""All input for the `updateCompany` mutation."""
+input UpdateCompanyInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Company` being updated.
+  """
+  patch: CompanyPatch!
+  id: Int!
 }
 
 """The output of our update `Company` mutation."""
@@ -1347,23 +1591,8 @@ type UpdateCompanyPayload {
   ): CompaniesEdge
 }
 
-"""All input for the `updateFishById` mutation."""
-input UpdateFishByIdInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-
-  """
-  An object where the defined keys will be set on the `Fish` being updated.
-  """
-  patch: FishPatch!
-  id: Int!
-}
-
-"""All input for the `updateFish` mutation."""
-input UpdateFishInput {
+"""All input for the `updateFishByNodeId` mutation."""
+input UpdateFishByNodeIdInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -1379,6 +1608,21 @@ input UpdateFishInput {
   An object where the defined keys will be set on the `Fish` being updated.
   """
   patch: FishPatch!
+}
+
+"""All input for the `updateFish` mutation."""
+input UpdateFishInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Fish` being updated.
+  """
+  patch: FishPatch!
+  id: Int!
 }
 
 """The output of our update `Fish` mutation."""
@@ -1407,8 +1651,8 @@ type UpdateFishPayload {
   ): FishEdge
 }
 
-"""All input for the `updatePondById` mutation."""
-input UpdatePondByIdInput {
+"""All input for the `updateFooGenusByNodeId` mutation."""
+input UpdateFooGenusByNodeIdInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -1416,14 +1660,56 @@ input UpdatePondByIdInput {
   clientMutationId: String
 
   """
-  An object where the defined keys will be set on the `Pond` being updated.
+  The globally unique `ID` which will identify a single `FooGenus` to be updated.
   """
-  patch: PondPatch!
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the `FooGenus` being updated.
+  """
+  patch: FooGenusPatch!
+}
+
+"""All input for the `updateFooGenus` mutation."""
+input UpdateFooGenusInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `FooGenus` being updated.
+  """
+  patch: FooGenusPatch!
   id: Int!
 }
 
-"""All input for the `updatePond` mutation."""
-input UpdatePondInput {
+"""The output of our update `FooGenus` mutation."""
+type UpdateFooGenusPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `FooGenus` that was updated by this mutation."""
+  fooGenus: FooGenus
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `FooGenus`. May be used by Relay 1."""
+  fooGenusEdge(
+    """The method to use when ordering `FooGenus`."""
+    orderBy: [FooGeneraOrderBy!] = PRIMARY_KEY_ASC
+  ): FooGeneraEdge
+}
+
+"""All input for the `updatePondByNodeId` mutation."""
+input UpdatePondByNodeIdInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -1439,6 +1725,21 @@ input UpdatePondInput {
   An object where the defined keys will be set on the `Pond` being updated.
   """
   patch: PondPatch!
+}
+
+"""All input for the `updatePond` mutation."""
+input UpdatePondInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Pond` being updated.
+  """
+  patch: PondPatch!
+  id: Int!
 }
 
 """The output of our update `Pond` mutation."""

--- a/schema.graphql.diff
+++ b/schema.graphql.diff
@@ -1,0 +1,1208 @@
+--- ./schema.graphql	2019-06-23 18:09:43.000000000 +0100
++++ ./schema.simplified.graphql	2019-06-23 18:09:44.000000000 +0100
+@@ -9,10 +9,10 @@
+   name: String!
+ 
+   """Reads a single `Company` that is related to this `Beverage`."""
+-  companyByCompanyId: Company
++  company: Company
+ 
+   """Reads a single `Company` that is related to this `Beverage`."""
+-  companyByDistributorId: Company
++  distributor: Company
+ }
+ 
+ """
+@@ -138,7 +138,7 @@
+   name: String!
+ 
+   """Reads and enables pagination through a set of `Beverage`."""
+-  beveragesByCompanyId(
++  beverages(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -167,7 +167,7 @@
+   ): BeveragesConnection!
+ 
+   """Reads and enables pagination through a set of `Beverage`."""
+-  beveragesByCompanyIdList(
++  beveragesList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -284,10 +284,10 @@
+   query: Query
+ 
+   """Reads a single `Company` that is related to this `Beverage`."""
+-  companyByCompanyId: Company
++  company: Company
+ 
+   """Reads a single `Company` that is related to this `Beverage`."""
+-  companyByDistributorId: Company
++  distributor: Company
+ 
+   """An edge for our `Beverage`. May be used by Relay 1."""
+   beverageEdge(
+@@ -360,7 +360,7 @@
+   query: Query
+ 
+   """Reads a single `Pond` that is related to this `Fish`."""
+-  pondByPondId: Pond
++  pond: Pond
+ 
+   """An edge for our `Fish`. May be used by Relay 1."""
+   fishEdge(
+@@ -369,39 +369,39 @@
+   ): FishEdge
+ }
+ 
+-"""All input for the create `FooGenera` mutation."""
+-input CreateFooGeneraInput {
++"""All input for the create `FooGenus` mutation."""
++input CreateFooGenusInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+ 
+-  """The `FooGenera` to be created by this mutation."""
+-  fooGenera: FooGeneraInput!
++  """The `FooGenus` to be created by this mutation."""
++  fooGenus: FooGenusInput!
+ }
+ 
+-"""The output of our create `FooGenera` mutation."""
+-type CreateFooGeneraPayload {
++"""The output of our create `FooGenus` mutation."""
++type CreateFooGenusPayload {
+   """
+   The exact same `clientMutationId` that was provided in the mutation input,
+   unchanged and unused. May be used by a client to track mutations.
+   """
+   clientMutationId: String
+ 
+-  """The `FooGenera` that was created by this mutation."""
+-  fooGenera: FooGenera
++  """The `FooGenus` that was created by this mutation."""
++  fooGenus: FooGenus
+ 
+   """
+   Our root query field type. Allows us to run any query from our mutation payload.
+   """
+   query: Query
+ 
+-  """An edge for our `FooGenera`. May be used by Relay 1."""
+-  fooGeneraEdge(
+-    """The method to use when ordering `FooGenera`."""
+-    orderBy: [FooGenerasOrderBy!] = PRIMARY_KEY_ASC
+-  ): FooGenerasEdge
++  """An edge for our `FooGenus`. May be used by Relay 1."""
++  fooGenusEdge(
++    """The method to use when ordering `FooGenus`."""
++    orderBy: [FooGeneraOrderBy!] = PRIMARY_KEY_ASC
++  ): FooGeneraEdge
+ }
+ 
+ """All input for the create `Pond` mutation."""
+@@ -442,14 +442,18 @@
+ """A location in a connection that can be used for resuming pagination."""
+ scalar Cursor
+ 
+-"""All input for the `deleteBeverageById` mutation."""
+-input DeleteBeverageByIdInput {
++"""All input for the `deleteBeverageByNodeId` mutation."""
++input DeleteBeverageByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-  id: Int!
++
++  """
++  The globally unique `ID` which will identify a single `Beverage` to be deleted.
++  """
++  nodeId: ID!
+ }
+ 
+ """All input for the `deleteBeverage` mutation."""
+@@ -459,11 +463,7 @@
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-
+-  """
+-  The globally unique `ID` which will identify a single `Beverage` to be deleted.
+-  """
+-  nodeId: ID!
++  id: Int!
+ }
+ 
+ """The output of our delete `Beverage` mutation."""
+@@ -476,7 +476,7 @@
+ 
+   """The `Beverage` that was deleted by this mutation."""
+   beverage: Beverage
+-  deletedBeverageId: ID
++  deletedBeverageNodeId: ID
+ 
+   """
+   Our root query field type. Allows us to run any query from our mutation payload.
+@@ -484,10 +484,10 @@
+   query: Query
+ 
+   """Reads a single `Company` that is related to this `Beverage`."""
+-  companyByCompanyId: Company
++  company: Company
+ 
+   """Reads a single `Company` that is related to this `Beverage`."""
+-  companyByDistributorId: Company
++  distributor: Company
+ 
+   """An edge for our `Beverage`. May be used by Relay 1."""
+   beverageEdge(
+@@ -496,14 +496,18 @@
+   ): BeveragesEdge
+ }
+ 
+-"""All input for the `deleteCompanyById` mutation."""
+-input DeleteCompanyByIdInput {
++"""All input for the `deleteCompanyByNodeId` mutation."""
++input DeleteCompanyByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-  id: Int!
++
++  """
++  The globally unique `ID` which will identify a single `Company` to be deleted.
++  """
++  nodeId: ID!
+ }
+ 
+ """All input for the `deleteCompany` mutation."""
+@@ -513,11 +517,7 @@
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-
+-  """
+-  The globally unique `ID` which will identify a single `Company` to be deleted.
+-  """
+-  nodeId: ID!
++  id: Int!
+ }
+ 
+ """The output of our delete `Company` mutation."""
+@@ -530,7 +530,7 @@
+ 
+   """The `Company` that was deleted by this mutation."""
+   company: Company
+-  deletedCompanyId: ID
++  deletedCompanyNodeId: ID
+ 
+   """
+   Our root query field type. Allows us to run any query from our mutation payload.
+@@ -544,14 +544,18 @@
+   ): CompaniesEdge
+ }
+ 
+-"""All input for the `deleteFishById` mutation."""
+-input DeleteFishByIdInput {
++"""All input for the `deleteFishByNodeId` mutation."""
++input DeleteFishByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-  id: Int!
++
++  """
++  The globally unique `ID` which will identify a single `Fish` to be deleted.
++  """
++  nodeId: ID!
+ }
+ 
+ """All input for the `deleteFish` mutation."""
+@@ -561,11 +565,7 @@
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-
+-  """
+-  The globally unique `ID` which will identify a single `Fish` to be deleted.
+-  """
+-  nodeId: ID!
++  id: Int!
+ }
+ 
+ """The output of our delete `Fish` mutation."""
+@@ -578,7 +578,7 @@
+ 
+   """The `Fish` that was deleted by this mutation."""
+   fish: Fish
+-  deletedFishId: ID
++  deletedFishNodeId: ID
+ 
+   """
+   Our root query field type. Allows us to run any query from our mutation payload.
+@@ -586,7 +586,7 @@
+   query: Query
+ 
+   """Reads a single `Pond` that is related to this `Fish`."""
+-  pondByPondId: Pond
++  pond: Pond
+ 
+   """An edge for our `Fish`. May be used by Relay 1."""
+   fishEdge(
+@@ -595,62 +595,66 @@
+   ): FishEdge
+ }
+ 
+-"""All input for the `deleteFooGeneraById` mutation."""
+-input DeleteFooGeneraByIdInput {
++"""All input for the `deleteFooGenusByNodeId` mutation."""
++input DeleteFooGenusByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-  id: Int!
++
++  """
++  The globally unique `ID` which will identify a single `FooGenus` to be deleted.
++  """
++  nodeId: ID!
+ }
+ 
+-"""All input for the `deleteFooGenera` mutation."""
+-input DeleteFooGeneraInput {
++"""All input for the `deleteFooGenus` mutation."""
++input DeleteFooGenusInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-
+-  """
+-  The globally unique `ID` which will identify a single `FooGenera` to be deleted.
+-  """
+-  nodeId: ID!
++  id: Int!
+ }
+ 
+-"""The output of our delete `FooGenera` mutation."""
+-type DeleteFooGeneraPayload {
++"""The output of our delete `FooGenus` mutation."""
++type DeleteFooGenusPayload {
+   """
+   The exact same `clientMutationId` that was provided in the mutation input,
+   unchanged and unused. May be used by a client to track mutations.
+   """
+   clientMutationId: String
+ 
+-  """The `FooGenera` that was deleted by this mutation."""
+-  fooGenera: FooGenera
+-  deletedFooGeneraId: ID
++  """The `FooGenus` that was deleted by this mutation."""
++  fooGenus: FooGenus
++  deletedFooGenusNodeId: ID
+ 
+   """
+   Our root query field type. Allows us to run any query from our mutation payload.
+   """
+   query: Query
+ 
+-  """An edge for our `FooGenera`. May be used by Relay 1."""
+-  fooGeneraEdge(
+-    """The method to use when ordering `FooGenera`."""
+-    orderBy: [FooGenerasOrderBy!] = PRIMARY_KEY_ASC
+-  ): FooGenerasEdge
++  """An edge for our `FooGenus`. May be used by Relay 1."""
++  fooGenusEdge(
++    """The method to use when ordering `FooGenus`."""
++    orderBy: [FooGeneraOrderBy!] = PRIMARY_KEY_ASC
++  ): FooGeneraEdge
+ }
+ 
+-"""All input for the `deletePondById` mutation."""
+-input DeletePondByIdInput {
++"""All input for the `deletePondByNodeId` mutation."""
++input DeletePondByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-  id: Int!
++
++  """
++  The globally unique `ID` which will identify a single `Pond` to be deleted.
++  """
++  nodeId: ID!
+ }
+ 
+ """All input for the `deletePond` mutation."""
+@@ -660,11 +664,7 @@
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-
+-  """
+-  The globally unique `ID` which will identify a single `Pond` to be deleted.
+-  """
+-  nodeId: ID!
++  id: Int!
+ }
+ 
+ """The output of our delete `Pond` mutation."""
+@@ -677,7 +677,7 @@
+ 
+   """The `Pond` that was deleted by this mutation."""
+   pond: Pond
+-  deletedPondId: ID
++  deletedPondNodeId: ID
+ 
+   """
+   Our root query field type. Allows us to run any query from our mutation payload.
+@@ -701,7 +701,7 @@
+   name: String!
+ 
+   """Reads a single `Pond` that is related to this `Fish`."""
+-  pondByPondId: Pond
++  pond: Pond
+ }
+ 
+ """
+@@ -773,7 +773,44 @@
+   name: String
+ }
+ 
+-type FooGenera implements Node {
++"""A connection to a list of `FooGenus` values."""
++type FooGeneraConnection {
++  """A list of `FooGenus` objects."""
++  nodes: [FooGenus]!
++
++  """
++  A list of edges which contains the `FooGenus` and cursor to aid in pagination.
++  """
++  edges: [FooGeneraEdge!]!
++
++  """Information to aid in pagination."""
++  pageInfo: PageInfo!
++
++  """The count of *all* `FooGenus` you could get from the connection."""
++  totalCount: Int!
++}
++
++"""A `FooGenus` edge in the connection."""
++type FooGeneraEdge {
++  """A cursor for use in pagination."""
++  cursor: Cursor
++
++  """The `FooGenus` at the end of the edge."""
++  node: FooGenus
++}
++
++"""Methods to use when ordering `FooGenus`."""
++enum FooGeneraOrderBy {
++  NATURAL
++  ID_ASC
++  ID_DESC
++  NAME_ASC
++  NAME_DESC
++  PRIMARY_KEY_ASC
++  PRIMARY_KEY_DESC
++}
++
++type FooGenus implements Node {
+   """
+   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+   """
+@@ -783,10 +820,10 @@
+ }
+ 
+ """
+-A condition to be used against `FooGenera` object types. All fields are tested
++A condition to be used against `FooGenus` object types. All fields are tested
+ for equality and combined with a logical ‘and.’
+ """
+-input FooGeneraCondition {
++input FooGenusCondition {
+   """Checks for equality with the object’s `id` field."""
+   id: Int
+ 
+@@ -794,57 +831,20 @@
+   name: String
+ }
+ 
+-"""An input for mutations affecting `FooGenera`"""
+-input FooGeneraInput {
++"""An input for mutations affecting `FooGenus`"""
++input FooGenusInput {
+   id: Int
+   name: String!
+ }
+ 
+ """
+-Represents an update to a `FooGenera`. Fields that are set will be updated.
++Represents an update to a `FooGenus`. Fields that are set will be updated.
+ """
+-input FooGeneraPatch {
++input FooGenusPatch {
+   id: Int
+   name: String
+ }
+ 
+-"""A connection to a list of `FooGenera` values."""
+-type FooGenerasConnection {
+-  """A list of `FooGenera` objects."""
+-  nodes: [FooGenera]!
+-
+-  """
+-  A list of edges which contains the `FooGenera` and cursor to aid in pagination.
+-  """
+-  edges: [FooGenerasEdge!]!
+-
+-  """Information to aid in pagination."""
+-  pageInfo: PageInfo!
+-
+-  """The count of *all* `FooGenera` you could get from the connection."""
+-  totalCount: Int!
+-}
+-
+-"""A `FooGenera` edge in the connection."""
+-type FooGenerasEdge {
+-  """A cursor for use in pagination."""
+-  cursor: Cursor
+-
+-  """The `FooGenera` at the end of the edge."""
+-  node: FooGenera
+-}
+-
+-"""Methods to use when ordering `FooGenera`."""
+-enum FooGenerasOrderBy {
+-  NATURAL
+-  ID_ASC
+-  ID_DESC
+-  NAME_ASC
+-  NAME_DESC
+-  PRIMARY_KEY_ASC
+-  PRIMARY_KEY_DESC
+-}
+-
+ """
+ The root mutation type which contains root level fields which mutate data.
+ """
+@@ -873,13 +873,13 @@
+     input: CreateFishInput!
+   ): CreateFishPayload
+ 
+-  """Creates a single `FooGenera`."""
+-  createFooGenera(
++  """Creates a single `FooGenus`."""
++  createFooGenus(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: CreateFooGeneraInput!
+-  ): CreateFooGeneraPayload
++    input: CreateFooGenusInput!
++  ): CreateFooGenusPayload
+ 
+   """Creates a single `Pond`."""
+   createPond(
+@@ -890,165 +890,163 @@
+   ): CreatePondPayload
+ 
+   """Updates a single `Beverage` using its globally unique id and a patch."""
+-  updateBeverage(
++  updateBeverageByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateBeverageInput!
++    input: UpdateBeverageByNodeIdInput!
+   ): UpdateBeveragePayload
+ 
+   """Updates a single `Beverage` using a unique key and a patch."""
+-  updateBeverageById(
++  updateBeverage(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateBeverageByIdInput!
++    input: UpdateBeverageInput!
+   ): UpdateBeveragePayload
+ 
+   """Updates a single `Company` using its globally unique id and a patch."""
+-  updateCompany(
++  updateCompanyByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateCompanyInput!
++    input: UpdateCompanyByNodeIdInput!
+   ): UpdateCompanyPayload
+ 
+   """Updates a single `Company` using a unique key and a patch."""
+-  updateCompanyById(
++  updateCompany(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateCompanyByIdInput!
++    input: UpdateCompanyInput!
+   ): UpdateCompanyPayload
+ 
+   """Updates a single `Fish` using its globally unique id and a patch."""
+-  updateFish(
++  updateFishByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateFishInput!
++    input: UpdateFishByNodeIdInput!
+   ): UpdateFishPayload
+ 
+   """Updates a single `Fish` using a unique key and a patch."""
+-  updateFishById(
++  updateFish(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateFishByIdInput!
++    input: UpdateFishInput!
+   ): UpdateFishPayload
+ 
+-  """
+-  Updates a single `FooGenera` using its globally unique id and a patch.
+-  """
+-  updateFooGenera(
++  """Updates a single `FooGenus` using its globally unique id and a patch."""
++  updateFooGenusByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateFooGeneraInput!
+-  ): UpdateFooGeneraPayload
++    input: UpdateFooGenusByNodeIdInput!
++  ): UpdateFooGenusPayload
+ 
+-  """Updates a single `FooGenera` using a unique key and a patch."""
+-  updateFooGeneraById(
++  """Updates a single `FooGenus` using a unique key and a patch."""
++  updateFooGenus(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateFooGeneraByIdInput!
+-  ): UpdateFooGeneraPayload
++    input: UpdateFooGenusInput!
++  ): UpdateFooGenusPayload
+ 
+   """Updates a single `Pond` using its globally unique id and a patch."""
+-  updatePond(
++  updatePondByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdatePondInput!
++    input: UpdatePondByNodeIdInput!
+   ): UpdatePondPayload
+ 
+   """Updates a single `Pond` using a unique key and a patch."""
+-  updatePondById(
++  updatePond(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdatePondByIdInput!
++    input: UpdatePondInput!
+   ): UpdatePondPayload
+ 
+   """Deletes a single `Beverage` using its globally unique id."""
+-  deleteBeverage(
++  deleteBeverageByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteBeverageInput!
++    input: DeleteBeverageByNodeIdInput!
+   ): DeleteBeveragePayload
+ 
+   """Deletes a single `Beverage` using a unique key."""
+-  deleteBeverageById(
++  deleteBeverage(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteBeverageByIdInput!
++    input: DeleteBeverageInput!
+   ): DeleteBeveragePayload
+ 
+   """Deletes a single `Company` using its globally unique id."""
+-  deleteCompany(
++  deleteCompanyByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteCompanyInput!
++    input: DeleteCompanyByNodeIdInput!
+   ): DeleteCompanyPayload
+ 
+   """Deletes a single `Company` using a unique key."""
+-  deleteCompanyById(
++  deleteCompany(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteCompanyByIdInput!
++    input: DeleteCompanyInput!
+   ): DeleteCompanyPayload
+ 
+   """Deletes a single `Fish` using its globally unique id."""
+-  deleteFish(
++  deleteFishByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteFishInput!
++    input: DeleteFishByNodeIdInput!
+   ): DeleteFishPayload
+ 
+   """Deletes a single `Fish` using a unique key."""
+-  deleteFishById(
++  deleteFish(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteFishByIdInput!
++    input: DeleteFishInput!
+   ): DeleteFishPayload
+ 
+-  """Deletes a single `FooGenera` using its globally unique id."""
+-  deleteFooGenera(
++  """Deletes a single `FooGenus` using its globally unique id."""
++  deleteFooGenusByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteFooGeneraInput!
+-  ): DeleteFooGeneraPayload
++    input: DeleteFooGenusByNodeIdInput!
++  ): DeleteFooGenusPayload
+ 
+-  """Deletes a single `FooGenera` using a unique key."""
+-  deleteFooGeneraById(
++  """Deletes a single `FooGenus` using a unique key."""
++  deleteFooGenus(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteFooGeneraByIdInput!
+-  ): DeleteFooGeneraPayload
++    input: DeleteFooGenusInput!
++  ): DeleteFooGenusPayload
+ 
+   """Deletes a single `Pond` using its globally unique id."""
+-  deletePond(
++  deletePondByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeletePondInput!
++    input: DeletePondByNodeIdInput!
+   ): DeletePondPayload
+ 
+   """Deletes a single `Pond` using a unique key."""
+-  deletePondById(
++  deletePond(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeletePondByIdInput!
++    input: DeletePondInput!
+   ): DeletePondPayload
+ }
+ 
+@@ -1084,7 +1082,7 @@
+   name: String!
+ 
+   """Reads and enables pagination through a set of `Fish`."""
+-  fishByPondId(
++  fishes(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1113,7 +1111,7 @@
+   ): FishConnection!
+ 
+   """Reads and enables pagination through a set of `Fish`."""
+-  fishByPondIdList(
++  fishesList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1212,7 +1210,7 @@
+   ): Node
+ 
+   """Reads and enables pagination through a set of `Beverage`."""
+-  allBeverages(
++  beverages(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1241,7 +1239,7 @@
+   ): BeveragesConnection
+ 
+   """Reads a set of `Beverage`."""
+-  allBeveragesList(
++  beveragesList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1258,7 +1256,7 @@
+   ): [Beverage!]
+ 
+   """Reads and enables pagination through a set of `Company`."""
+-  allCompanies(
++  companies(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1287,7 +1285,7 @@
+   ): CompaniesConnection
+ 
+   """Reads a set of `Company`."""
+-  allCompaniesList(
++  companiesList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1304,7 +1302,7 @@
+   ): [Company!]
+ 
+   """Reads and enables pagination through a set of `Fish`."""
+-  allFish(
++  fishes(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1333,7 +1331,7 @@
+   ): FishConnection
+ 
+   """Reads a set of `Fish`."""
+-  allFishList(
++  fishesList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1349,8 +1347,8 @@
+     condition: FishCondition
+   ): [Fish!]
+ 
+-  """Reads and enables pagination through a set of `FooGenera`."""
+-  allFooGeneras(
++  """Reads and enables pagination through a set of `FooGenus`."""
++  fooGenera(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1369,34 +1367,34 @@
+     """Read all values in the set after (below) this cursor."""
+     after: Cursor
+ 
+-    """The method to use when ordering `FooGenera`."""
+-    orderBy: [FooGenerasOrderBy!] = [PRIMARY_KEY_ASC]
++    """The method to use when ordering `FooGenus`."""
++    orderBy: [FooGeneraOrderBy!] = [PRIMARY_KEY_ASC]
+ 
+     """
+     A condition to be used in determining which values should be returned by the collection.
+     """
+-    condition: FooGeneraCondition
+-  ): FooGenerasConnection
++    condition: FooGenusCondition
++  ): FooGeneraConnection
+ 
+-  """Reads a set of `FooGenera`."""
+-  allFooGenerasList(
++  """Reads a set of `FooGenus`."""
++  fooGeneraList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+     """Skip the first `n` values."""
+     offset: Int
+ 
+-    """The method to use when ordering `FooGenera`."""
+-    orderBy: [FooGenerasOrderBy!]
++    """The method to use when ordering `FooGenus`."""
++    orderBy: [FooGeneraOrderBy!]
+ 
+     """
+     A condition to be used in determining which values should be returned by the collection.
+     """
+-    condition: FooGeneraCondition
+-  ): [FooGenera!]
++    condition: FooGenusCondition
++  ): [FooGenus!]
+ 
+   """Reads and enables pagination through a set of `Pond`."""
+-  allPonds(
++  ponds(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1425,7 +1423,7 @@
+   ): PondsConnection
+ 
+   """Reads a set of `Pond`."""
+-  allPondsList(
++  pondsList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1440,47 +1438,45 @@
+     """
+     condition: PondCondition
+   ): [Pond!]
+-  beverageById(id: Int!): Beverage
+-  companyById(id: Int!): Company
+-  fishById(id: Int!): Fish
+-  fooGeneraById(id: Int!): FooGenera
+-  pondById(id: Int!): Pond
++  beverage(id: Int!): Beverage
++  company(id: Int!): Company
++  fish(id: Int!): Fish
++  fooGenus(id: Int!): FooGenus
++  pond(id: Int!): Pond
+ 
+   """Reads a single `Beverage` using its globally unique `ID`."""
+-  beverage(
++  beverageByNodeId(
+     """The globally unique `ID` to be used in selecting a single `Beverage`."""
+     nodeId: ID!
+   ): Beverage
+ 
+   """Reads a single `Company` using its globally unique `ID`."""
+-  company(
++  companyByNodeId(
+     """The globally unique `ID` to be used in selecting a single `Company`."""
+     nodeId: ID!
+   ): Company
+ 
+   """Reads a single `Fish` using its globally unique `ID`."""
+-  fish(
++  fishByNodeId(
+     """The globally unique `ID` to be used in selecting a single `Fish`."""
+     nodeId: ID!
+   ): Fish
+ 
+-  """Reads a single `FooGenera` using its globally unique `ID`."""
+-  fooGenera(
+-    """
+-    The globally unique `ID` to be used in selecting a single `FooGenera`.
+-    """
++  """Reads a single `FooGenus` using its globally unique `ID`."""
++  fooGenusByNodeId(
++    """The globally unique `ID` to be used in selecting a single `FooGenus`."""
+     nodeId: ID!
+-  ): FooGenera
++  ): FooGenus
+ 
+   """Reads a single `Pond` using its globally unique `ID`."""
+-  pond(
++  pondByNodeId(
+     """The globally unique `ID` to be used in selecting a single `Pond`."""
+     nodeId: ID!
+   ): Pond
+ }
+ 
+-"""All input for the `updateBeverageById` mutation."""
+-input UpdateBeverageByIdInput {
++"""All input for the `updateBeverageByNodeId` mutation."""
++input UpdateBeverageByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+@@ -1488,10 +1484,14 @@
+   clientMutationId: String
+ 
+   """
++  The globally unique `ID` which will identify a single `Beverage` to be updated.
++  """
++  nodeId: ID!
++
++  """
+   An object where the defined keys will be set on the `Beverage` being updated.
+   """
+-  beveragePatch: BeveragePatch!
+-  id: Int!
++  patch: BeveragePatch!
+ }
+ 
+ """All input for the `updateBeverage` mutation."""
+@@ -1503,14 +1503,10 @@
+   clientMutationId: String
+ 
+   """
+-  The globally unique `ID` which will identify a single `Beverage` to be updated.
+-  """
+-  nodeId: ID!
+-
+-  """
+   An object where the defined keys will be set on the `Beverage` being updated.
+   """
+-  beveragePatch: BeveragePatch!
++  patch: BeveragePatch!
++  id: Int!
+ }
+ 
+ """The output of our update `Beverage` mutation."""
+@@ -1530,10 +1526,10 @@
+   query: Query
+ 
+   """Reads a single `Company` that is related to this `Beverage`."""
+-  companyByCompanyId: Company
++  company: Company
+ 
+   """Reads a single `Company` that is related to this `Beverage`."""
+-  companyByDistributorId: Company
++  distributor: Company
+ 
+   """An edge for our `Beverage`. May be used by Relay 1."""
+   beverageEdge(
+@@ -1542,8 +1538,8 @@
+   ): BeveragesEdge
+ }
+ 
+-"""All input for the `updateCompanyById` mutation."""
+-input UpdateCompanyByIdInput {
++"""All input for the `updateCompanyByNodeId` mutation."""
++input UpdateCompanyByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+@@ -1551,10 +1547,14 @@
+   clientMutationId: String
+ 
+   """
++  The globally unique `ID` which will identify a single `Company` to be updated.
++  """
++  nodeId: ID!
++
++  """
+   An object where the defined keys will be set on the `Company` being updated.
+   """
+-  companyPatch: CompanyPatch!
+-  id: Int!
++  patch: CompanyPatch!
+ }
+ 
+ """All input for the `updateCompany` mutation."""
+@@ -1566,14 +1566,10 @@
+   clientMutationId: String
+ 
+   """
+-  The globally unique `ID` which will identify a single `Company` to be updated.
+-  """
+-  nodeId: ID!
+-
+-  """
+   An object where the defined keys will be set on the `Company` being updated.
+   """
+-  companyPatch: CompanyPatch!
++  patch: CompanyPatch!
++  id: Int!
+ }
+ 
+ """The output of our update `Company` mutation."""
+@@ -1599,8 +1595,8 @@
+   ): CompaniesEdge
+ }
+ 
+-"""All input for the `updateFishById` mutation."""
+-input UpdateFishByIdInput {
++"""All input for the `updateFishByNodeId` mutation."""
++input UpdateFishByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+@@ -1608,10 +1604,14 @@
+   clientMutationId: String
+ 
+   """
++  The globally unique `ID` which will identify a single `Fish` to be updated.
++  """
++  nodeId: ID!
++
++  """
+   An object where the defined keys will be set on the `Fish` being updated.
+   """
+-  fishPatch: FishPatch!
+-  id: Int!
++  patch: FishPatch!
+ }
+ 
+ """All input for the `updateFish` mutation."""
+@@ -1623,14 +1623,10 @@
+   clientMutationId: String
+ 
+   """
+-  The globally unique `ID` which will identify a single `Fish` to be updated.
+-  """
+-  nodeId: ID!
+-
+-  """
+   An object where the defined keys will be set on the `Fish` being updated.
+   """
+-  fishPatch: FishPatch!
++  patch: FishPatch!
++  id: Int!
+ }
+ 
+ """The output of our update `Fish` mutation."""
+@@ -1650,7 +1646,7 @@
+   query: Query
+ 
+   """Reads a single `Pond` that is related to this `Fish`."""
+-  pondByPondId: Pond
++  pond: Pond
+ 
+   """An edge for our `Fish`. May be used by Relay 1."""
+   fishEdge(
+@@ -1659,8 +1655,8 @@
+   ): FishEdge
+ }
+ 
+-"""All input for the `updateFooGeneraById` mutation."""
+-input UpdateFooGeneraByIdInput {
++"""All input for the `updateFooGenusByNodeId` mutation."""
++input UpdateFooGenusByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+@@ -1668,14 +1664,18 @@
+   clientMutationId: String
+ 
+   """
+-  An object where the defined keys will be set on the `FooGenera` being updated.
++  The globally unique `ID` which will identify a single `FooGenus` to be updated.
+   """
+-  fooGeneraPatch: FooGeneraPatch!
+-  id: Int!
++  nodeId: ID!
++
++  """
++  An object where the defined keys will be set on the `FooGenus` being updated.
++  """
++  patch: FooGenusPatch!
+ }
+ 
+-"""All input for the `updateFooGenera` mutation."""
+-input UpdateFooGeneraInput {
++"""All input for the `updateFooGenus` mutation."""
++input UpdateFooGenusInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+@@ -1683,41 +1683,37 @@
+   clientMutationId: String
+ 
+   """
+-  The globally unique `ID` which will identify a single `FooGenera` to be updated.
+-  """
+-  nodeId: ID!
+-
+-  """
+-  An object where the defined keys will be set on the `FooGenera` being updated.
++  An object where the defined keys will be set on the `FooGenus` being updated.
+   """
+-  fooGeneraPatch: FooGeneraPatch!
++  patch: FooGenusPatch!
++  id: Int!
+ }
+ 
+-"""The output of our update `FooGenera` mutation."""
+-type UpdateFooGeneraPayload {
++"""The output of our update `FooGenus` mutation."""
++type UpdateFooGenusPayload {
+   """
+   The exact same `clientMutationId` that was provided in the mutation input,
+   unchanged and unused. May be used by a client to track mutations.
+   """
+   clientMutationId: String
+ 
+-  """The `FooGenera` that was updated by this mutation."""
+-  fooGenera: FooGenera
++  """The `FooGenus` that was updated by this mutation."""
++  fooGenus: FooGenus
+ 
+   """
+   Our root query field type. Allows us to run any query from our mutation payload.
+   """
+   query: Query
+ 
+-  """An edge for our `FooGenera`. May be used by Relay 1."""
+-  fooGeneraEdge(
+-    """The method to use when ordering `FooGenera`."""
+-    orderBy: [FooGenerasOrderBy!] = PRIMARY_KEY_ASC
+-  ): FooGenerasEdge
++  """An edge for our `FooGenus`. May be used by Relay 1."""
++  fooGenusEdge(
++    """The method to use when ordering `FooGenus`."""
++    orderBy: [FooGeneraOrderBy!] = PRIMARY_KEY_ASC
++  ): FooGeneraEdge
+ }
+ 
+-"""All input for the `updatePondById` mutation."""
+-input UpdatePondByIdInput {
++"""All input for the `updatePondByNodeId` mutation."""
++input UpdatePondByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+@@ -1725,10 +1721,14 @@
+   clientMutationId: String
+ 
+   """
++  The globally unique `ID` which will identify a single `Pond` to be updated.
++  """
++  nodeId: ID!
++
++  """
+   An object where the defined keys will be set on the `Pond` being updated.
+   """
+-  pondPatch: PondPatch!
+-  id: Int!
++  patch: PondPatch!
+ }
+ 
+ """All input for the `updatePond` mutation."""
+@@ -1740,14 +1740,10 @@
+   clientMutationId: String
+ 
+   """
+-  The globally unique `ID` which will identify a single `Pond` to be updated.
+-  """
+-  nodeId: ID!
+-
+-  """
+   An object where the defined keys will be set on the `Pond` being updated.
+   """
+-  pondPatch: PondPatch!
++  patch: PondPatch!
++  id: Int!
+ }
+ 
+ """The output of our update `Pond` mutation."""

--- a/schema.simplified.graphql
+++ b/schema.simplified.graphql
@@ -764,7 +764,9 @@ enum FishOrderBy {
   PRIMARY_KEY_DESC
 }
 
-"""Represents an update to a `Fish`. Fields that are set will be updated."""
+"""
+Represents an update to a `Fish`. Fields that are set will be updated.
+"""
 input FishPatch {
   id: Int
   pondId: Int
@@ -1143,7 +1145,9 @@ input PondInput {
   name: String!
 }
 
-"""Represents an update to a `Pond`. Fields that are set will be updated."""
+"""
+Represents an update to a `Pond`. Fields that are set will be updated.
+"""
 input PondPatch {
   id: Int
   name: String

--- a/schema.simplified.graphql
+++ b/schema.simplified.graphql
@@ -65,7 +65,7 @@ type BeveragesConnection {
   pageInfo: PageInfo!
 
   """The count of *all* `Beverage` you could get from the connection."""
-  totalCount: Int
+  totalCount: Int!
 }
 
 """A `Beverage` edge in the connection."""
@@ -106,7 +106,7 @@ type CompaniesConnection {
   pageInfo: PageInfo!
 
   """The count of *all* `Company` you could get from the connection."""
-  totalCount: Int
+  totalCount: Int!
 }
 
 """A `Company` edge in the connection."""
@@ -369,6 +369,41 @@ type CreateFishPayload {
   ): FishEdge
 }
 
+"""All input for the create `FooGenus` mutation."""
+input CreateFooGenusInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `FooGenus` to be created by this mutation."""
+  fooGenus: FooGenusInput!
+}
+
+"""The output of our create `FooGenus` mutation."""
+type CreateFooGenusPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `FooGenus` that was created by this mutation."""
+  fooGenus: FooGenus
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `FooGenus`. May be used by Relay 1."""
+  fooGenusEdge(
+    """The method to use when ordering `FooGenus`."""
+    orderBy: [FooGeneraOrderBy!] = PRIMARY_KEY_ASC
+  ): FooGeneraEdge
+}
+
 """All input for the create `Pond` mutation."""
 input CreatePondInput {
   """
@@ -407,18 +442,8 @@ type CreatePondPayload {
 """A location in a connection that can be used for resuming pagination."""
 scalar Cursor
 
-"""All input for the `deleteBeverageById` mutation."""
-input DeleteBeverageByIdInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-  id: Int!
-}
-
-"""All input for the `deleteBeverage` mutation."""
-input DeleteBeverageInput {
+"""All input for the `deleteBeverageByNodeId` mutation."""
+input DeleteBeverageByNodeIdInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -431,6 +456,16 @@ input DeleteBeverageInput {
   nodeId: ID!
 }
 
+"""All input for the `deleteBeverage` mutation."""
+input DeleteBeverageInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
 """The output of our delete `Beverage` mutation."""
 type DeleteBeveragePayload {
   """
@@ -441,7 +476,7 @@ type DeleteBeveragePayload {
 
   """The `Beverage` that was deleted by this mutation."""
   beverage: Beverage
-  deletedBeverageId: ID
+  deletedBeverageNodeId: ID
 
   """
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -461,18 +496,8 @@ type DeleteBeveragePayload {
   ): BeveragesEdge
 }
 
-"""All input for the `deleteCompanyById` mutation."""
-input DeleteCompanyByIdInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-  id: Int!
-}
-
-"""All input for the `deleteCompany` mutation."""
-input DeleteCompanyInput {
+"""All input for the `deleteCompanyByNodeId` mutation."""
+input DeleteCompanyByNodeIdInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -485,6 +510,16 @@ input DeleteCompanyInput {
   nodeId: ID!
 }
 
+"""All input for the `deleteCompany` mutation."""
+input DeleteCompanyInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
 """The output of our delete `Company` mutation."""
 type DeleteCompanyPayload {
   """
@@ -495,7 +530,7 @@ type DeleteCompanyPayload {
 
   """The `Company` that was deleted by this mutation."""
   company: Company
-  deletedCompanyId: ID
+  deletedCompanyNodeId: ID
 
   """
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -509,18 +544,8 @@ type DeleteCompanyPayload {
   ): CompaniesEdge
 }
 
-"""All input for the `deleteFishById` mutation."""
-input DeleteFishByIdInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-  id: Int!
-}
-
-"""All input for the `deleteFish` mutation."""
-input DeleteFishInput {
+"""All input for the `deleteFishByNodeId` mutation."""
+input DeleteFishByNodeIdInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -533,6 +558,16 @@ input DeleteFishInput {
   nodeId: ID!
 }
 
+"""All input for the `deleteFish` mutation."""
+input DeleteFishInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
 """The output of our delete `Fish` mutation."""
 type DeleteFishPayload {
   """
@@ -543,7 +578,7 @@ type DeleteFishPayload {
 
   """The `Fish` that was deleted by this mutation."""
   fish: Fish
-  deletedFishId: ID
+  deletedFishNodeId: ID
 
   """
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -560,8 +595,22 @@ type DeleteFishPayload {
   ): FishEdge
 }
 
-"""All input for the `deletePondById` mutation."""
-input DeletePondByIdInput {
+"""All input for the `deleteFooGenusByNodeId` mutation."""
+input DeleteFooGenusByNodeIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `FooGenus` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""All input for the `deleteFooGenus` mutation."""
+input DeleteFooGenusInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -570,8 +619,32 @@ input DeletePondByIdInput {
   id: Int!
 }
 
-"""All input for the `deletePond` mutation."""
-input DeletePondInput {
+"""The output of our delete `FooGenus` mutation."""
+type DeleteFooGenusPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `FooGenus` that was deleted by this mutation."""
+  fooGenus: FooGenus
+  deletedFooGenusNodeId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `FooGenus`. May be used by Relay 1."""
+  fooGenusEdge(
+    """The method to use when ordering `FooGenus`."""
+    orderBy: [FooGeneraOrderBy!] = PRIMARY_KEY_ASC
+  ): FooGeneraEdge
+}
+
+"""All input for the `deletePondByNodeId` mutation."""
+input DeletePondByNodeIdInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -584,6 +657,16 @@ input DeletePondInput {
   nodeId: ID!
 }
 
+"""All input for the `deletePond` mutation."""
+input DeletePondInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
 """The output of our delete `Pond` mutation."""
 type DeletePondPayload {
   """
@@ -594,7 +677,7 @@ type DeletePondPayload {
 
   """The `Pond` that was deleted by this mutation."""
   pond: Pond
-  deletedPondId: ID
+  deletedPondNodeId: ID
 
   """
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -649,7 +732,7 @@ type FishConnection {
   pageInfo: PageInfo!
 
   """The count of *all* `Fish` you could get from the connection."""
-  totalCount: Int
+  totalCount: Int!
 }
 
 """A `Fish` edge in the connection."""
@@ -681,12 +764,82 @@ enum FishOrderBy {
   PRIMARY_KEY_DESC
 }
 
-"""
-Represents an update to a `Fish`. Fields that are set will be updated.
-"""
+"""Represents an update to a `Fish`. Fields that are set will be updated."""
 input FishPatch {
   id: Int
   pondId: Int
+  name: String
+}
+
+"""A connection to a list of `FooGenus` values."""
+type FooGeneraConnection {
+  """A list of `FooGenus` objects."""
+  nodes: [FooGenus]!
+
+  """
+  A list of edges which contains the `FooGenus` and cursor to aid in pagination.
+  """
+  edges: [FooGeneraEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `FooGenus` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `FooGenus` edge in the connection."""
+type FooGeneraEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `FooGenus` at the end of the edge."""
+  node: FooGenus
+}
+
+"""Methods to use when ordering `FooGenus`."""
+enum FooGeneraOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+type FooGenus implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  name: String!
+}
+
+"""
+A condition to be used against `FooGenus` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input FooGenusCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `name` field."""
+  name: String
+}
+
+"""An input for mutations affecting `FooGenus`"""
+input FooGenusInput {
+  id: Int
+  name: String!
+}
+
+"""
+Represents an update to a `FooGenus`. Fields that are set will be updated.
+"""
+input FooGenusPatch {
+  id: Int
   name: String
 }
 
@@ -718,6 +871,14 @@ type Mutation {
     input: CreateFishInput!
   ): CreateFishPayload
 
+  """Creates a single `FooGenus`."""
+  createFooGenus(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateFooGenusInput!
+  ): CreateFooGenusPayload
+
   """Creates a single `Pond`."""
   createPond(
     """
@@ -727,6 +888,14 @@ type Mutation {
   ): CreatePondPayload
 
   """Updates a single `Beverage` using its globally unique id and a patch."""
+  updateBeverageByNodeId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateBeverageByNodeIdInput!
+  ): UpdateBeveragePayload
+
+  """Updates a single `Beverage` using a unique key and a patch."""
   updateBeverage(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -734,15 +903,15 @@ type Mutation {
     input: UpdateBeverageInput!
   ): UpdateBeveragePayload
 
-  """Updates a single `Beverage` using a unique key and a patch."""
-  updateBeverageById(
+  """Updates a single `Company` using its globally unique id and a patch."""
+  updateCompanyByNodeId(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: UpdateBeverageByIdInput!
-  ): UpdateBeveragePayload
+    input: UpdateCompanyByNodeIdInput!
+  ): UpdateCompanyPayload
 
-  """Updates a single `Company` using its globally unique id and a patch."""
+  """Updates a single `Company` using a unique key and a patch."""
   updateCompany(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -750,15 +919,15 @@ type Mutation {
     input: UpdateCompanyInput!
   ): UpdateCompanyPayload
 
-  """Updates a single `Company` using a unique key and a patch."""
-  updateCompanyById(
+  """Updates a single `Fish` using its globally unique id and a patch."""
+  updateFishByNodeId(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: UpdateCompanyByIdInput!
-  ): UpdateCompanyPayload
+    input: UpdateFishByNodeIdInput!
+  ): UpdateFishPayload
 
-  """Updates a single `Fish` using its globally unique id and a patch."""
+  """Updates a single `Fish` using a unique key and a patch."""
   updateFish(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -766,15 +935,31 @@ type Mutation {
     input: UpdateFishInput!
   ): UpdateFishPayload
 
-  """Updates a single `Fish` using a unique key and a patch."""
-  updateFishById(
+  """Updates a single `FooGenus` using its globally unique id and a patch."""
+  updateFooGenusByNodeId(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: UpdateFishByIdInput!
-  ): UpdateFishPayload
+    input: UpdateFooGenusByNodeIdInput!
+  ): UpdateFooGenusPayload
+
+  """Updates a single `FooGenus` using a unique key and a patch."""
+  updateFooGenus(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateFooGenusInput!
+  ): UpdateFooGenusPayload
 
   """Updates a single `Pond` using its globally unique id and a patch."""
+  updatePondByNodeId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdatePondByNodeIdInput!
+  ): UpdatePondPayload
+
+  """Updates a single `Pond` using a unique key and a patch."""
   updatePond(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -782,15 +967,15 @@ type Mutation {
     input: UpdatePondInput!
   ): UpdatePondPayload
 
-  """Updates a single `Pond` using a unique key and a patch."""
-  updatePondById(
+  """Deletes a single `Beverage` using its globally unique id."""
+  deleteBeverageByNodeId(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: UpdatePondByIdInput!
-  ): UpdatePondPayload
+    input: DeleteBeverageByNodeIdInput!
+  ): DeleteBeveragePayload
 
-  """Deletes a single `Beverage` using its globally unique id."""
+  """Deletes a single `Beverage` using a unique key."""
   deleteBeverage(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -798,15 +983,15 @@ type Mutation {
     input: DeleteBeverageInput!
   ): DeleteBeveragePayload
 
-  """Deletes a single `Beverage` using a unique key."""
-  deleteBeverageById(
+  """Deletes a single `Company` using its globally unique id."""
+  deleteCompanyByNodeId(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: DeleteBeverageByIdInput!
-  ): DeleteBeveragePayload
+    input: DeleteCompanyByNodeIdInput!
+  ): DeleteCompanyPayload
 
-  """Deletes a single `Company` using its globally unique id."""
+  """Deletes a single `Company` using a unique key."""
   deleteCompany(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -814,15 +999,15 @@ type Mutation {
     input: DeleteCompanyInput!
   ): DeleteCompanyPayload
 
-  """Deletes a single `Company` using a unique key."""
-  deleteCompanyById(
+  """Deletes a single `Fish` using its globally unique id."""
+  deleteFishByNodeId(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: DeleteCompanyByIdInput!
-  ): DeleteCompanyPayload
+    input: DeleteFishByNodeIdInput!
+  ): DeleteFishPayload
 
-  """Deletes a single `Fish` using its globally unique id."""
+  """Deletes a single `Fish` using a unique key."""
   deleteFish(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -830,28 +1015,36 @@ type Mutation {
     input: DeleteFishInput!
   ): DeleteFishPayload
 
-  """Deletes a single `Fish` using a unique key."""
-  deleteFishById(
+  """Deletes a single `FooGenus` using its globally unique id."""
+  deleteFooGenusByNodeId(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: DeleteFishByIdInput!
-  ): DeleteFishPayload
+    input: DeleteFooGenusByNodeIdInput!
+  ): DeleteFooGenusPayload
+
+  """Deletes a single `FooGenus` using a unique key."""
+  deleteFooGenus(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteFooGenusInput!
+  ): DeleteFooGenusPayload
 
   """Deletes a single `Pond` using its globally unique id."""
+  deletePondByNodeId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeletePondByNodeIdInput!
+  ): DeletePondPayload
+
+  """Deletes a single `Pond` using a unique key."""
   deletePond(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
     input: DeletePondInput!
-  ): DeletePondPayload
-
-  """Deletes a single `Pond` using a unique key."""
-  deletePondById(
-    """
-    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    """
-    input: DeletePondByIdInput!
   ): DeletePondPayload
 }
 
@@ -950,9 +1143,7 @@ input PondInput {
   name: String!
 }
 
-"""
-Represents an update to a `Pond`. Fields that are set will be updated.
-"""
+"""Represents an update to a `Pond`. Fields that are set will be updated."""
 input PondPatch {
   id: Int
   name: String
@@ -972,7 +1163,7 @@ type PondsConnection {
   pageInfo: PageInfo!
 
   """The count of *all* `Pond` you could get from the connection."""
-  totalCount: Int
+  totalCount: Int!
 }
 
 """A `Pond` edge in the connection."""
@@ -1152,6 +1343,52 @@ type Query implements Node {
     condition: FishCondition
   ): [Fish!]
 
+  """Reads and enables pagination through a set of `FooGenus`."""
+  fooGenera(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `FooGenus`."""
+    orderBy: [FooGeneraOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: FooGenusCondition
+  ): FooGeneraConnection
+
+  """Reads a set of `FooGenus`."""
+  fooGeneraList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `FooGenus`."""
+    orderBy: [FooGeneraOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: FooGenusCondition
+  ): [FooGenus!]
+
   """Reads and enables pagination through a set of `Pond`."""
   ponds(
     """Only read the first `n` values of the set."""
@@ -1197,53 +1434,45 @@ type Query implements Node {
     """
     condition: PondCondition
   ): [Pond!]
-  beverageById(id: Int!): Beverage
-  companyById(id: Int!): Company
-  fishById(id: Int!): Fish
-  pondById(id: Int!): Pond
+  beverage(id: Int!): Beverage
+  company(id: Int!): Company
+  fish(id: Int!): Fish
+  fooGenus(id: Int!): FooGenus
+  pond(id: Int!): Pond
 
   """Reads a single `Beverage` using its globally unique `ID`."""
-  beverage(
+  beverageByNodeId(
     """The globally unique `ID` to be used in selecting a single `Beverage`."""
     nodeId: ID!
   ): Beverage
 
   """Reads a single `Company` using its globally unique `ID`."""
-  company(
+  companyByNodeId(
     """The globally unique `ID` to be used in selecting a single `Company`."""
     nodeId: ID!
   ): Company
 
   """Reads a single `Fish` using its globally unique `ID`."""
-  fish(
+  fishByNodeId(
     """The globally unique `ID` to be used in selecting a single `Fish`."""
     nodeId: ID!
   ): Fish
 
+  """Reads a single `FooGenus` using its globally unique `ID`."""
+  fooGenusByNodeId(
+    """The globally unique `ID` to be used in selecting a single `FooGenus`."""
+    nodeId: ID!
+  ): FooGenus
+
   """Reads a single `Pond` using its globally unique `ID`."""
-  pond(
+  pondByNodeId(
     """The globally unique `ID` to be used in selecting a single `Pond`."""
     nodeId: ID!
   ): Pond
 }
 
-"""All input for the `updateBeverageById` mutation."""
-input UpdateBeverageByIdInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-
-  """
-  An object where the defined keys will be set on the `Beverage` being updated.
-  """
-  patch: BeveragePatch!
-  id: Int!
-}
-
-"""All input for the `updateBeverage` mutation."""
-input UpdateBeverageInput {
+"""All input for the `updateBeverageByNodeId` mutation."""
+input UpdateBeverageByNodeIdInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -1259,6 +1488,21 @@ input UpdateBeverageInput {
   An object where the defined keys will be set on the `Beverage` being updated.
   """
   patch: BeveragePatch!
+}
+
+"""All input for the `updateBeverage` mutation."""
+input UpdateBeverageInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Beverage` being updated.
+  """
+  patch: BeveragePatch!
+  id: Int!
 }
 
 """The output of our update `Beverage` mutation."""
@@ -1290,23 +1534,8 @@ type UpdateBeveragePayload {
   ): BeveragesEdge
 }
 
-"""All input for the `updateCompanyById` mutation."""
-input UpdateCompanyByIdInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-
-  """
-  An object where the defined keys will be set on the `Company` being updated.
-  """
-  patch: CompanyPatch!
-  id: Int!
-}
-
-"""All input for the `updateCompany` mutation."""
-input UpdateCompanyInput {
+"""All input for the `updateCompanyByNodeId` mutation."""
+input UpdateCompanyByNodeIdInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -1322,6 +1551,21 @@ input UpdateCompanyInput {
   An object where the defined keys will be set on the `Company` being updated.
   """
   patch: CompanyPatch!
+}
+
+"""All input for the `updateCompany` mutation."""
+input UpdateCompanyInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Company` being updated.
+  """
+  patch: CompanyPatch!
+  id: Int!
 }
 
 """The output of our update `Company` mutation."""
@@ -1347,23 +1591,8 @@ type UpdateCompanyPayload {
   ): CompaniesEdge
 }
 
-"""All input for the `updateFishById` mutation."""
-input UpdateFishByIdInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-
-  """
-  An object where the defined keys will be set on the `Fish` being updated.
-  """
-  patch: FishPatch!
-  id: Int!
-}
-
-"""All input for the `updateFish` mutation."""
-input UpdateFishInput {
+"""All input for the `updateFishByNodeId` mutation."""
+input UpdateFishByNodeIdInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -1379,6 +1608,21 @@ input UpdateFishInput {
   An object where the defined keys will be set on the `Fish` being updated.
   """
   patch: FishPatch!
+}
+
+"""All input for the `updateFish` mutation."""
+input UpdateFishInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Fish` being updated.
+  """
+  patch: FishPatch!
+  id: Int!
 }
 
 """The output of our update `Fish` mutation."""
@@ -1407,8 +1651,8 @@ type UpdateFishPayload {
   ): FishEdge
 }
 
-"""All input for the `updatePondById` mutation."""
-input UpdatePondByIdInput {
+"""All input for the `updateFooGenusByNodeId` mutation."""
+input UpdateFooGenusByNodeIdInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -1416,14 +1660,56 @@ input UpdatePondByIdInput {
   clientMutationId: String
 
   """
-  An object where the defined keys will be set on the `Pond` being updated.
+  The globally unique `ID` which will identify a single `FooGenus` to be updated.
   """
-  patch: PondPatch!
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the `FooGenus` being updated.
+  """
+  patch: FooGenusPatch!
+}
+
+"""All input for the `updateFooGenus` mutation."""
+input UpdateFooGenusInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `FooGenus` being updated.
+  """
+  patch: FooGenusPatch!
   id: Int!
 }
 
-"""All input for the `updatePond` mutation."""
-input UpdatePondInput {
+"""The output of our update `FooGenus` mutation."""
+type UpdateFooGenusPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `FooGenus` that was updated by this mutation."""
+  fooGenus: FooGenus
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `FooGenus`. May be used by Relay 1."""
+  fooGenusEdge(
+    """The method to use when ordering `FooGenus`."""
+    orderBy: [FooGeneraOrderBy!] = PRIMARY_KEY_ASC
+  ): FooGeneraEdge
+}
+
+"""All input for the `updatePondByNodeId` mutation."""
+input UpdatePondByNodeIdInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -1439,6 +1725,21 @@ input UpdatePondInput {
   An object where the defined keys will be set on the `Pond` being updated.
   """
   patch: PondPatch!
+}
+
+"""All input for the `updatePond` mutation."""
+input UpdatePondInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Pond` being updated.
+  """
+  patch: PondPatch!
+  id: Int!
 }
 
 """The output of our update `Pond` mutation."""

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,13 @@
+#!/bin/bash
+set -e -x
 dropdb pg_simplify_inflectors || true
 createdb pg_simplify_inflectors
 psql pg_simplify_inflectors -f test.sql
-yarn postgraphile -c pg_simplify_inflectors -s app_public --simple-collections both -X --export-schema-graphql ./schema.graphql
-yarn postgraphile -c pg_simplify_inflectors -s app_public --simple-collections both -X --export-schema-graphql ./schema.simplified.graphql
+npx postgraphile -c pg_simplify_inflectors -s app_public --simple-collections both -X --export-schema-graphql ./schema.graphql
+npx postgraphile -c pg_simplify_inflectors -s app_public --simple-collections both -X --append-plugins "`pwd`/index.js" --export-schema-graphql ./schema.simplified.graphql
+if command -v colordiff; then
+  COLORDIFF="colordiff"
+else
+  COLORDIFF="cat"
+fi;
+diff -u ./schema.graphql ./schema.simplified.graphql | $COLORDIFF

--- a/test.sh
+++ b/test.sh
@@ -10,4 +10,4 @@ if command -v colordiff; then
 else
   COLORDIFF="cat"
 fi;
-diff -u ./schema.graphql ./schema.simplified.graphql | $COLORDIFF
+diff -u ./schema.graphql ./schema.simplified.graphql | tee schema.diff | $COLORDIFF

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,5 @@
-psql simplify -f test.sql
-yarn postgraphile -c simplify -s app_public --simple-collections both -X --export-schema-graphql ./schema.graphql
-yarn postgraphile -c simplify -s app_public --simple-collections both -X --export-schema-graphql ./schema.simplified.graphql
+dropdb pg_simplify_inflectors || true
+createdb pg_simplify_inflectors
+psql pg_simplify_inflectors -f test.sql
+yarn postgraphile -c pg_simplify_inflectors -s app_public --simple-collections both -X --export-schema-graphql ./schema.graphql
+yarn postgraphile -c pg_simplify_inflectors -s app_public --simple-collections both -X --export-schema-graphql ./schema.simplified.graphql

--- a/test.sh
+++ b/test.sh
@@ -10,4 +10,4 @@ if command -v colordiff; then
 else
   COLORDIFF="cat"
 fi;
-diff -u ./schema.graphql ./schema.simplified.graphql | tee schema.diff | $COLORDIFF
+diff -u ./schema.graphql ./schema.simplified.graphql | tee schema.graphql.diff | $COLORDIFF

--- a/test.sql
+++ b/test.sql
@@ -26,7 +26,7 @@ create table beverages (
   name text not null
 );
 comment on constraint "beverages_distributor_id_fkey" on "beverages" is
-  E'@foreignFieldName distributedBeverages';
+  E'@foreignFieldName distributedBeverages\n@foreignSimpleFieldName distributedBeveragesList';
 
 create table foo_genera(
   id serial primary key,

--- a/test.sql
+++ b/test.sql
@@ -27,3 +27,8 @@ create table beverages (
 );
 comment on constraint "beverages_distributor_id_fkey" on "beverages" is
   E'@foreignFieldName distributedBeverages';
+
+create table foo_genera(
+  id serial primary key,
+  name text not null
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@graphile/lru@4.4.1-alpha.2", "@graphile/lru@^4.4.1-alpha.2":
+  version "4.4.1-alpha.2"
+  resolved "https://registry.yarnpkg.com/@graphile/lru/-/lru-4.4.1-alpha.2.tgz#4b5fc0c1203bb45da45fc65e62d2210c30643c2b"
+  integrity sha512-FOWiyZWV4NiKRqfYCXJMc/CFP5SsX1BsZkPDrWtqrNTVZePkXKgrTsJQbvkhwftoPcT8basC7x7YjvOkXInHgg==
+
 "@types/accepts@*":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/accepts/-/accepts-1.3.5.tgz#c34bec115cfc746e04fe5a059df4ce7e7b391575"
@@ -57,20 +62,20 @@
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
 
-"@types/graphql@^14.0.3":
-  version "14.0.4"
-  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-14.0.4.tgz#d71a75967cd93c33eaea32b626b362ce0f2b2ae9"
-  integrity sha512-gI98ANelzzpq7lZzuYCUJg8LZDjQc7ekj7cxoWt8RezOKaVaAyK27U6AHa9LEqikP1NUhyi8blQQkHYHVRZ7Tg==
+"@types/graphql@^14.0.3", "@types/graphql@^14.2.0":
+  version "14.2.1"
+  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-14.2.1.tgz#02027ff799aa4dc5aa88ff2eed4058d29e7eb491"
+  integrity sha512-81YjgyCz+kYDXkPuk1j4+jCgFjM4DubzrI88tvpWOQp5eILa0A/KvtGAbXONPhD6vRa3neiFb/ES1IDQ82n5Rw==
 
 "@types/http-assert@*":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@types/http-assert/-/http-assert-1.4.0.tgz#41d173466e396e99a14d75f7160cc997f2f9ed8b"
   integrity sha512-TZDqvFW4nQwL9DVSNJIJu4lPLttKgzRF58COa7Vs42Ki/MrhIqUbeIw0MWn4kGLiZLXB7oCBibm7nkSjPkzfKQ==
 
-"@types/jsonwebtoken@<7.2.1":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-7.2.0.tgz#0fed32c8501da80ac9839d2d403a65c83d776ffd"
-  integrity sha1-D+0yyFAdqArJg50tQDplyD13b/0=
+"@types/jsonwebtoken@^8.3.2":
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-8.3.2.tgz#e3d5245197152346fae7ee87d5541aa5a92d0362"
+  integrity sha512-Mkjljd9DTpkPlrmGfTJvcP4aBU7yO2QmW7wNVhV4/6AEUxYoacqU7FJU/N0yFEHTsIrE4da3rUrjrR5ejicFmA==
   dependencies:
     "@types/node" "*"
 
@@ -113,10 +118,10 @@
   dependencies:
     moment ">=2.14.0"
 
-"@types/pg@^7.4.10":
-  version "7.4.11"
-  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-7.4.11.tgz#dcc560e89c17d859c83c91ad3faf60bfeacaad6c"
-  integrity sha512-Eksj2yOBNHnNqLuU1AqwF1qXgdaYDcWVH1ZQlxS7k1i34+JZd/ZNd15ugIpTVQxmBBMqjliJstmrnusjXy08Tg==
+"@types/pg@>=6 <8", "@types/pg@^7.4.10":
+  version "7.4.14"
+  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-7.4.14.tgz#8235910120e81ca671e0e62b7de77d048b9a22b2"
+  integrity sha512-2e4XapP9V/X42IGByC5IHzCzHqLLCNJid8iZBbkk6lkaDMvli8Rk62YE9wjGcLD5Qr5Zaw1ShkQyXy91PI8C0Q==
   dependencies:
     "@types/node" "*"
     "@types/pg-types" "*"
@@ -134,15 +139,13 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-ansi-regex@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
-
-ansi-styles@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
-  integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
+"@types/ws@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-6.0.1.tgz#ca7a3f3756aa12f62a0a62145ed14c6db25d5a28"
+  integrity sha512-EzH8k1gyZ4xih/MaZTXwT2xOkPiIMSrhQ9b8wrlX88L0T02eYsddatQlwVFlEPyEqV0ChpdpNnE51QPH6NVT4Q==
+  dependencies:
+    "@types/events" "*"
+    "@types/node" "*"
 
 ansi-styles@^3.2.1:
   version "3.2.1"
@@ -150,6 +153,16 @@ ansi-styles@^3.2.1:
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
+
+async-limiter@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
+  integrity sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
+
+backo2@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
+  integrity sha1-MasayLEpNjRj41s+u2n038+6eUc=
 
 body-parser@^1.15.2:
   version "1.18.3"
@@ -182,21 +195,10 @@ bytes@3.0.0:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
   integrity sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=
 
-chalk@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
-  integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
-  dependencies:
-    ansi-styles "^2.2.1"
-    escape-string-regexp "^1.0.2"
-    has-ansi "^2.0.0"
-    strip-ansi "^3.0.0"
-    supports-color "^2.0.0"
-
-chalk@^2.1.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
-  integrity sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==
+chalk@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
   dependencies:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
@@ -224,22 +226,29 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
-debug@2.6.9, "debug@>=2 <3", debug@^2.3.3:
+debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
 
+"debug@>=3 <5", debug@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
 depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
-ecdsa-sig-formatter@1.0.10:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz#1c595000f04a8897dfb85000892a0f4c33af86c3"
-  integrity sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=
+ecdsa-sig-formatter@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
   dependencies:
     safe-buffer "^5.0.1"
 
@@ -258,10 +267,15 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+
+eventemitter3@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
+  integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
 
 finalhandler@^1.0.6:
   version "1.1.1"
@@ -276,47 +290,50 @@ finalhandler@^1.0.6:
     statuses "~1.4.0"
     unpipe "~1.0.0"
 
-graphile-build-pg@4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/graphile-build-pg/-/graphile-build-pg-4.2.0.tgz#4c8b279b94bcafb0bfc21b32f542660bf32f53b1"
-  integrity sha512-UApYkNb0aIkT/6MjInXniH3eTH4H2I9sR0biaulwBAXLukqpB/ttxWrzWbbGZF4dWZ0+uRjZNNyrK5OGdsHHtg==
+graphile-build-pg@4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/graphile-build-pg/-/graphile-build-pg-4.4.1.tgz#329e79056ba888f29174439c519051e78bb2308c"
+  integrity sha512-Itpi3ShIG+KoRYvgSTXDSGvf2sRUIW+WGO3UIWeS9avFWGQvu5VvvEFZrZTFrha+w4mxvZqb+cSvncMx4Pe3rg==
   dependencies:
-    chalk "^2.1.0"
-    debug ">=2 <3"
-    graphile-build "4.1.0"
+    "@graphile/lru" "4.4.1-alpha.2"
+    chalk "^2.4.2"
+    debug "^4.1.1"
+    graphile-build "4.4.1"
     graphql-iso-date "^3.6.0"
-    jsonwebtoken "^8.1.1"
+    jsonwebtoken "^8.5.1"
     lodash ">=4 <5"
     lru-cache ">=4 <5"
-    pg-sql2 "2.2.1"
-    postgres-interval "^1.1.1"
+    pg-sql2 "4.4.1-alpha.2"
+    postgres-interval "^1.2.0"
 
-graphile-build@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/graphile-build/-/graphile-build-4.1.0.tgz#d1ee6bee8c53ec1b82db3dcd9a343151bdaac8f2"
-  integrity sha512-N1IEmDDgTPIf4jpLVuyhdiuQBpKNu8lMpnVTTmfuYf5GZvGz6hJzTvSZREnIoF3lPQ+JS4zMfb7KuVNOYdYu8Q==
+graphile-build@4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/graphile-build/-/graphile-build-4.4.1.tgz#5a2b4e3bfa94daf26343c5190746a4e13880c5c7"
+  integrity sha512-WxOzrl6MjQSja9WSAyFG2Q5cc5KCA436GOymJVWILEaDnvHOA3ir51Ks4ZQxIEiUf654ctyuqOw+tLPDCI5Kyg==
   dependencies:
-    "@types/graphql" "^14.0.3"
-    chalk "^2.1.0"
-    debug ">=2 <3"
-    graphql-parse-resolve-info "4.1.0"
+    "@graphile/lru" "4.4.1-alpha.2"
+    "@types/graphql" "^14.2.0"
+    chalk "^2.4.2"
+    debug "^4.1.1"
+    graphql-parse-resolve-info "4.4.1-alpha.1"
+    iterall "^1.2.2"
     lodash ">=4 <5"
-    lru-cache ">=4 <5"
+    lru-cache "^5.0.0"
     pluralize "^7.0.0"
-    semver "^5.6.0"
+    semver "^6.0.0"
 
 graphql-iso-date@^3.6.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/graphql-iso-date/-/graphql-iso-date-3.6.1.tgz#bd2d0dc886e0f954cbbbc496bbf1d480b57ffa96"
   integrity sha512-AwFGIuYMJQXOEAgRlJlFL4H1ncFM8n8XmoVDTNypNOZyQ8LFDG2ppMFlsS862BSTCDcSUfHp8PD3/uJhv7t59Q==
 
-graphql-parse-resolve-info@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/graphql-parse-resolve-info/-/graphql-parse-resolve-info-4.1.0.tgz#fa52bc9d8aeec210e3ad92cca30d3c36a5e814c3"
-  integrity sha512-qDRgykBm1rbyGAlduPuGtKXHlZtUcNgM8Rg6C/gDVcLww9vNV6h0nmCulpYYPWzATnAVGV8ISnLUDFCU9Y+qcA==
+graphql-parse-resolve-info@4.4.1-alpha.1:
+  version "4.4.1-alpha.1"
+  resolved "https://registry.yarnpkg.com/graphql-parse-resolve-info/-/graphql-parse-resolve-info-4.4.1-alpha.1.tgz#41e57bf92904017f6479cf639056b3843c2d33b1"
+  integrity sha512-RVjzdVmsa1X1djWJFkTTm0VbE42grzdF3Jzy0yY2EQkn+1zq4LHFQbbPLDaNFMNc8vO+FI14zO0VJHP4HIaFpQ==
   dependencies:
-    "@types/graphql" "^14.0.3"
-    debug ">=2 <3"
+    "@types/graphql" "^14.2.0"
+    debug "^4.1.1"
 
 "graphql@^0.6.0 || ^0.7.0 || ^0.8.0-b || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.2":
   version "14.0.2"
@@ -324,13 +341,6 @@ graphql-parse-resolve-info@4.1.0:
   integrity sha512-gUC4YYsaiSJT1h40krG3J+USGlwhzNTXSb4IOZljn9ag5Tj+RkoXrWp+Kh7WyE3t1NCfab5kzCuxBIvOMERMXw==
   dependencies:
     iterall "^1.2.2"
-
-has-ansi@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
-  integrity sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
-  dependencies:
-    ansi-regex "^2.0.0"
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -370,17 +380,17 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-iterall@^1.2.2:
+iterall@^1.0.2, iterall@^1.2.1, iterall@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
   integrity sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==
 
-jsonwebtoken@^8.0.0, jsonwebtoken@^8.1.1:
-  version "8.4.0"
-  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.4.0.tgz#8757f7b4cb7440d86d5e2f3becefa70536c8e46a"
-  integrity sha512-coyXjRTCy0pw5WYBpMvWOMN+Kjaik2MwTUIq9cna/W7NpO9E+iYbumZONAz3hcr+tXFJECoQVrtmIoC3Oz0gvg==
+jsonwebtoken@^8.0.0, jsonwebtoken@^8.5.1:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
+  integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
   dependencies:
-    jws "^3.1.5"
+    jws "^3.2.2"
     lodash.includes "^4.3.0"
     lodash.isboolean "^3.0.3"
     lodash.isinteger "^4.0.4"
@@ -389,22 +399,23 @@ jsonwebtoken@^8.0.0, jsonwebtoken@^8.1.1:
     lodash.isstring "^4.0.1"
     lodash.once "^4.0.0"
     ms "^2.1.1"
+    semver "^5.6.0"
 
-jwa@^1.1.5:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.1.6.tgz#87240e76c9808dbde18783cf2264ef4929ee50e6"
-  integrity sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
   dependencies:
     buffer-equal-constant-time "1.0.1"
-    ecdsa-sig-formatter "1.0.10"
+    ecdsa-sig-formatter "1.0.11"
     safe-buffer "^5.0.1"
 
-jws@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/jws/-/jws-3.1.5.tgz#80d12d05b293d1e841e7cb8b4e69e561adcf834f"
-  integrity sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
   dependencies:
-    jwa "^1.1.5"
+    jwa "^1.4.1"
     safe-buffer "^5.0.1"
 
 lodash.includes@^4.3.0:
@@ -455,6 +466,13 @@ lodash.once@^4.0.0:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+lru-cache@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  dependencies:
+    yallist "^3.0.2"
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
@@ -504,23 +522,29 @@ parseurl@^1.3.2, parseurl@~1.3.2:
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
   integrity sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=
 
-pg-connection-string@0.1.3, pg-connection-string@^0.1.3:
+pg-connection-string@0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-0.1.3.tgz#da1847b20940e42ee1492beaf65d49d91b245df7"
   integrity sha1-2hhHsglA5C7hSSvq9l1J2RskXfc=
+
+pg-connection-string@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.1.0.tgz#e07258f280476540b24818ebb5dca29e101ca502"
+  integrity sha512-bhlV7Eq09JrRIvo1eKngpwuqKtJnNhZdpdOlvrPrA4dxqXPjxSrbNrfnIDmTpwMyRszrcV4kU5ZA4mMsQUrjdg==
 
 pg-pool@^2.0.4:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-2.0.5.tgz#f00556fab23f1bbb14b0650ba8d0e447434a1b04"
   integrity sha512-T4W9qzP2LjItXuXbW6jgAF2AY0jHp6IoTxRhM3GB7yzfBxzDnA3GCm0sAduzmmiCybMqD0+V1HiqIG5X2YWqlQ==
 
-pg-sql2@2.2.1, pg-sql2@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/pg-sql2/-/pg-sql2-2.2.1.tgz#a37612e5243887c5135a6849dec1f20b2cf00553"
-  integrity sha512-S4XyLvUJv/rUMNk4+4LuT7S/aWKlQifi6ekHeshNWn0FZJxq5t4qw2VzCfbTNM3mQN7c9B6rM01FcnbRI37Y2Q==
+pg-sql2@4.4.1-alpha.2, pg-sql2@^4.4.1-alpha.2:
+  version "4.4.1-alpha.2"
+  resolved "https://registry.yarnpkg.com/pg-sql2/-/pg-sql2-4.4.1-alpha.2.tgz#037a08e5f7956b4a23451feb82cf53946a3700b0"
+  integrity sha512-m0jfYdr3AHSqKz26paeHtW/qT4B9REMGKCXt/SGodsNKYMm7GmgYyBikzC7o9VRTiMjtCWtmXAXZDtih8rfc8g==
   dependencies:
-    "@types/pg" "^7.4.10"
-    debug ">=2 <3"
+    "@graphile/lru" "4.4.1-alpha.2"
+    "@types/pg" ">=6 <8"
+    debug ">=3 <5"
 
 pg-types@~1.12.1:
   version "1.12.1"
@@ -557,39 +581,43 @@ pluralize@^7.0.0:
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
   integrity sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==
 
-postgraphile-core@4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/postgraphile-core/-/postgraphile-core-4.2.0.tgz#ee5d42f04629ce1225665fedb78f491b1f8491f0"
-  integrity sha512-9SJKV+/0jINUUPQPN3TtoSEG4tI47DOZEY9Qg4sq6Yxnf5/Yr9OFImLUj8c6wxfvq5/+7Ajqny1OGnS1fnwg1Q==
+postgraphile-core@4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/postgraphile-core/-/postgraphile-core-4.4.1.tgz#e923cd314698b7698cc3ddbdf2b8dfc8cbea2a05"
+  integrity sha512-qZ+uQOZ2tjRcoO8+/1KjkP+LzK/5jC6IaxZI4XiduHHGTtZyMWcU94HK4DyVEuMtt5PUIB3q3SR6x70huyPPlA==
   dependencies:
-    "@types/graphql" "^14.0.3"
-    graphile-build "4.1.0"
-    graphile-build-pg "4.2.0"
+    "@types/graphql" "^14.2.0"
+    graphile-build "4.4.1"
+    graphile-build-pg "4.4.1"
 
-postgraphile@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/postgraphile/-/postgraphile-4.2.0.tgz#1a3401ff827b5d2cfb3fe49a58fae5d93145ce09"
-  integrity sha512-S6aHo0R951wWZJLKf/jPKkRw9HhtygPL57+yZGEuWTgcHpayqG7lC3A5Zplkatlwg8ASD4w1X+7QnY8tL4YDxg==
+postgraphile@4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/postgraphile/-/postgraphile-4.4.1.tgz#205db7b8b908f9d8eefd366ac48991b59f9ad639"
+  integrity sha512-QslqgxJwQT1lBn/lXNlOk46tgq7C+swRsQa1yMw481JUsyu9eebWrVOxdv22tg51JIWx/yrVdX3pSV7hs+LrYg==
   dependencies:
+    "@graphile/lru" "^4.4.1-alpha.2"
     "@types/graphql" "^14.0.3"
-    "@types/jsonwebtoken" "<7.2.1"
+    "@types/jsonwebtoken" "^8.3.2"
     "@types/koa" "^2.0.44"
     "@types/pg" "^7.4.10"
+    "@types/ws" "^6.0.1"
     body-parser "^1.15.2"
-    chalk "^1.1.3"
+    chalk "^2.4.2"
     commander "^2.19.0"
-    debug "^2.3.3"
+    debug "^4.1.1"
     finalhandler "^1.0.6"
     graphql "^0.6.0 || ^0.7.0 || ^0.8.0-b || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.2"
     http-errors "^1.5.1"
+    iterall "^1.0.2"
     jsonwebtoken "^8.0.0"
-    lru-cache ">=4 <5"
     parseurl "^1.3.2"
     pg ">=6.1.0 <8"
-    pg-connection-string "^0.1.3"
-    pg-sql2 "^2.2.1"
-    postgraphile-core "4.2.0"
+    pg-connection-string "^2.0.0"
+    pg-sql2 "^4.4.1-alpha.2"
+    postgraphile-core "4.4.1"
+    subscriptions-transport-ws "^0.9.15"
     tslib "^1.5.0"
+    ws "^6.1.3"
 
 postgres-array@~1.0.0:
   version "1.0.3"
@@ -606,10 +634,10 @@ postgres-date@~1.0.0:
   resolved "https://registry.yarnpkg.com/postgres-date/-/postgres-date-1.0.3.tgz#e2d89702efdb258ff9d9cee0fe91bd06975257a8"
   integrity sha1-4tiXAu/bJY/52c7g/pG9BpdSV6g=
 
-postgres-interval@^1.1.0, postgres-interval@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/postgres-interval/-/postgres-interval-1.1.2.tgz#bf71ff902635f21cb241a013fc421d81d1db15a9"
-  integrity sha512-fC3xNHeTskCxL1dC8KOtxXt7YeFmlbTYtn7ul8MkVERuTmf7pI4DrkAxcw3kh1fQ9uz4wQmd03a1mRiXUZChfQ==
+postgres-interval@^1.1.0, postgres-interval@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/postgres-interval/-/postgres-interval-1.2.0.tgz#b460c82cb1587507788819a06aa0fffdb3544695"
+  integrity sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==
   dependencies:
     xtend "^4.0.0"
 
@@ -658,6 +686,11 @@ semver@^5.6.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
 
+semver@^6.0.0:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.1.1.tgz#53f53da9b30b2103cd4f15eab3a18ecbcb210c9b"
+  integrity sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==
+
 setprototypeof@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
@@ -680,17 +713,16 @@ statuses@~1.4.0:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
   integrity sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==
 
-strip-ansi@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
-  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
+subscriptions-transport-ws@^0.9.15:
+  version "0.9.16"
+  resolved "https://registry.yarnpkg.com/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.16.tgz#90a422f0771d9c32069294c08608af2d47f596ec"
+  integrity sha512-pQdoU7nC+EpStXnCfh/+ho0zE0Z+ma+i7xvj7bkXKb1dvYHSZxgRPaU6spRP+Bjzow67c/rRDoix5RT0uU9omw==
   dependencies:
-    ansi-regex "^2.0.0"
-
-supports-color@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
-  integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
+    backo2 "^1.0.2"
+    eventemitter3 "^3.1.0"
+    iterall "^1.2.1"
+    symbol-observable "^1.0.4"
+    ws "^5.2.0"
 
 supports-color@^5.3.0:
   version "5.5.0"
@@ -698,6 +730,11 @@ supports-color@^5.3.0:
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
+
+symbol-observable@^1.0.4:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 through@2:
   version "2.3.8"
@@ -727,6 +764,20 @@ unpipe@1.0.0, unpipe@~1.0.0:
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
 
+ws@^5.2.0:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
+  integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
+  dependencies:
+    async-limiter "~1.0.0"
+
+ws@^6.1.3:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
+  integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
+  dependencies:
+    async-limiter "~1.0.0"
+
 xtend@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
@@ -736,3 +787,8 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
+
+yallist@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
+  integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==


### PR DESCRIPTION
Fixes https://github.com/graphile-contrib/pg-simplify-inflector/issues/21.

"For any [special cases](https://github.com/blakeembrey/pluralize/blob/master/pluralize.js#L273) in pluralize, if your table name contains more than one word they will get pluralized incorrectly. For example the table species would show up in the schema as singular type Species, but the table plant_species would show up as type PlantSpecy."

After this PR, pluralize and singularize will only be run on the final segment of a word, so special cased words will return proper results.