### PR TITLE
Simplify multikey relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v6.0.0
+
+Simplify multi-key relationships.
+
+Unique relations get shorter-named reverse field.
+
 # v5.0.0-beta.1
 
 # v5.0.0-beta.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# v5.0.0-beta.1
+
+# v5.0.0-beta.0
+
+More advanced guesses at field names for reverse relations. Ability to omit
+list suffix, simplify patch names, turn on/off simplifying of the 'all' from
+'allUsers', ability to change the 'ById' primary key fields to not have that
+suffix and instead have the node ID fetchers have a suffix.
+
+# v3.0.0
+
+Simplifies naming in more of the schema.
+
 # v2.0.0
 
 Breaking change: single relation names based on a single key are now named

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ function PgSimplifyInflectorPlugin(
     pgSimplifyPatch = true,
     pgSimplifyAllRows = true,
     pgShortPk = true,
+    pgSimplifyMultikeyRelations = true,
     nodeIdFieldName = "nodeId",
   }
 ) {
@@ -137,6 +138,16 @@ function PgSimplifyInflectorPlugin(
           const key = detailedKeys[0];
           const columnName = this._columnName(key);
           return this.getBaseName(columnName);
+        }
+        if (pgSimplifyMultikeyRelations) {
+          const columnNames = detailedKeys.map(key => this._columnName(key));
+          const baseNames = columnNames.map(columnName =>
+            this.getBaseName(columnName)
+          );
+          // Check none are null
+          if (baseNames.every(n => n)) {
+            return baseNames.join("-");
+          }
         }
         return null;
       },

--- a/test.js
+++ b/test.js
@@ -61,6 +61,9 @@ async function runTests(pool, dir) {
   const schema = await fsp.readFile(`${ROOT}/${dir}/schema.sql`, "utf8");
   await withClient(pool, async client => {
     await client.query(`
+      set search_path to public;
+      create extension if not exists pgcrypto;
+
       drop schema if exists app_public cascade;
       create schema app_public;
       set search_path to app_public, public;

--- a/test.js
+++ b/test.js
@@ -79,9 +79,21 @@ async function runTests(pool, dir) {
     await fsp.writeFile(afterPath, printSchema(after));
 
     const diff = await new Promise((resolve, reject) => {
-      const child = child_process.spawn("diff", ["-u", beforePath, afterPath], {
-        stdio: "pipe",
-      });
+      const child = child_process.spawn(
+        "diff",
+        [
+          "-u",
+          "--label",
+          "unsimplified",
+          beforePath,
+          "--label",
+          "simplified",
+          afterPath,
+        ],
+        {
+          stdio: "pipe",
+        }
+      );
       const buffers = [];
 
       child.stdout.on("data", data => {

--- a/tests/companies/schema.graphql.diff
+++ b/tests/companies/schema.graphql.diff
@@ -1,5 +1,5 @@
---- /home/benjie/Dev/graphile/pg-simplify-inflector/tests/companies/schema.unsimplified.graphql	2020-04-14 12:20:02.206937652 +0100
-+++ /home/benjie/Dev/graphile/pg-simplify-inflector/tests/companies/schema.simplified.graphql	2020-04-14 12:20:02.210937652 +0100
+--- unsimplified
++++ simplified
 @@ -9,10 +9,10 @@
    name: String!
  

--- a/tests/fish/schema.graphql.diff
+++ b/tests/fish/schema.graphql.diff
@@ -1,5 +1,5 @@
---- /home/benjie/Dev/graphile/pg-simplify-inflector/tests/fish/schema.unsimplified.graphql	2020-04-14 12:20:02.722937651 +0100
-+++ /home/benjie/Dev/graphile/pg-simplify-inflector/tests/fish/schema.simplified.graphql	2020-04-14 12:20:02.726937651 +0100
+--- unsimplified
++++ simplified
 @@ -27,7 +27,7 @@
    query: Query
  

--- a/tests/multikey_refs/schema.graphql.diff
+++ b/tests/multikey_refs/schema.graphql.diff
@@ -1,0 +1,1006 @@
+--- /home/benjie/Dev/graphile/pg-simplify-inflector/tests/multikey_refs/schema.unsimplified.graphql	2020-04-14 12:28:00.530919438 +0100
++++ /home/benjie/Dev/graphile/pg-simplify-inflector/tests/multikey_refs/schema.simplified.graphql	2020-04-14 12:28:00.530919438 +0100
+@@ -29,16 +29,16 @@
+   """
+   Reads a single `Organization` that is related to this `GoalContributor`.
+   """
+-  organizationByOrganizationId: Organization
++  organization: Organization
+ 
+   """Reads a single `Goal` that is related to this `GoalContributor`."""
+-  goalByOrganizationIdAndTeamIdAndGoalUuid: Goal
++  organizationTeamGoal: Goal
+ 
+   """Reads a single `Team` that is related to this `GoalContributor`."""
+-  teamByTeamId: Team
++  team: Team
+ 
+   """Reads a single `User` that is related to this `GoalContributor`."""
+-  userByContributorId: User
++  contributor: User
+ 
+   """An edge for our `GoalContributor`. May be used by Relay 1."""
+   goalContributorEdge(
+@@ -76,10 +76,10 @@
+   query: Query
+ 
+   """Reads a single `Organization` that is related to this `Goal`."""
+-  organizationByOrganizationId: Organization
++  organization: Organization
+ 
+   """Reads a single `Team` that is related to this `Goal`."""
+-  teamByTeamId: Team
++  team: Team
+ 
+   """An edge for our `Goal`. May be used by Relay 1."""
+   goalEdge(
+@@ -196,28 +196,32 @@
+ """A location in a connection that can be used for resuming pagination."""
+ scalar Cursor
+ 
+-"""
+-All input for the `deleteGoalByOrganizationIdAndTeamIdAndGoalUuid` mutation.
+-"""
+-input DeleteGoalByOrganizationIdAndTeamIdAndGoalUuidInput {
++"""All input for the `deleteGoalByNodeId` mutation."""
++input DeleteGoalByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-  organizationId: Int!
+-  teamId: Int!
+-  goalUuid: UUID!
++
++  """
++  The globally unique `ID` which will identify a single `Goal` to be deleted.
++  """
++  nodeId: ID!
+ }
+ 
+-"""All input for the `deleteGoalContributorById` mutation."""
+-input DeleteGoalContributorByIdInput {
++"""All input for the `deleteGoalContributorByNodeId` mutation."""
++input DeleteGoalContributorByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-  id: Int!
++
++  """
++  The globally unique `ID` which will identify a single `GoalContributor` to be deleted.
++  """
++  nodeId: ID!
+ }
+ 
+ """All input for the `deleteGoalContributor` mutation."""
+@@ -227,11 +231,7 @@
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-
+-  """
+-  The globally unique `ID` which will identify a single `GoalContributor` to be deleted.
+-  """
+-  nodeId: ID!
++  id: Int!
+ }
+ 
+ """The output of our delete `GoalContributor` mutation."""
+@@ -244,7 +244,7 @@
+ 
+   """The `GoalContributor` that was deleted by this mutation."""
+   goalContributor: GoalContributor
+-  deletedGoalContributorId: ID
++  deletedGoalContributorNodeId: ID
+ 
+   """
+   Our root query field type. Allows us to run any query from our mutation payload.
+@@ -254,16 +254,16 @@
+   """
+   Reads a single `Organization` that is related to this `GoalContributor`.
+   """
+-  organizationByOrganizationId: Organization
++  organization: Organization
+ 
+   """Reads a single `Goal` that is related to this `GoalContributor`."""
+-  goalByOrganizationIdAndTeamIdAndGoalUuid: Goal
++  organizationTeamGoal: Goal
+ 
+   """Reads a single `Team` that is related to this `GoalContributor`."""
+-  teamByTeamId: Team
++  team: Team
+ 
+   """Reads a single `User` that is related to this `GoalContributor`."""
+-  userByContributorId: User
++  contributor: User
+ 
+   """An edge for our `GoalContributor`. May be used by Relay 1."""
+   goalContributorEdge(
+@@ -279,11 +279,9 @@
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-
+-  """
+-  The globally unique `ID` which will identify a single `Goal` to be deleted.
+-  """
+-  nodeId: ID!
++  organizationId: Int!
++  teamId: Int!
++  goalUuid: UUID!
+ }
+ 
+ """The output of our delete `Goal` mutation."""
+@@ -296,7 +294,7 @@
+ 
+   """The `Goal` that was deleted by this mutation."""
+   goal: Goal
+-  deletedGoalId: ID
++  deletedGoalNodeId: ID
+ 
+   """
+   Our root query field type. Allows us to run any query from our mutation payload.
+@@ -304,10 +302,10 @@
+   query: Query
+ 
+   """Reads a single `Organization` that is related to this `Goal`."""
+-  organizationByOrganizationId: Organization
++  organization: Organization
+ 
+   """Reads a single `Team` that is related to this `Goal`."""
+-  teamByTeamId: Team
++  team: Team
+ 
+   """An edge for our `Goal`. May be used by Relay 1."""
+   goalEdge(
+@@ -316,14 +314,18 @@
+   ): GoalsEdge
+ }
+ 
+-"""All input for the `deleteOrganizationById` mutation."""
+-input DeleteOrganizationByIdInput {
++"""All input for the `deleteOrganizationByNodeId` mutation."""
++input DeleteOrganizationByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-  id: Int!
++
++  """
++  The globally unique `ID` which will identify a single `Organization` to be deleted.
++  """
++  nodeId: ID!
+ }
+ 
+ """All input for the `deleteOrganization` mutation."""
+@@ -333,11 +335,7 @@
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-
+-  """
+-  The globally unique `ID` which will identify a single `Organization` to be deleted.
+-  """
+-  nodeId: ID!
++  id: Int!
+ }
+ 
+ """The output of our delete `Organization` mutation."""
+@@ -350,7 +348,7 @@
+ 
+   """The `Organization` that was deleted by this mutation."""
+   organization: Organization
+-  deletedOrganizationId: ID
++  deletedOrganizationNodeId: ID
+ 
+   """
+   Our root query field type. Allows us to run any query from our mutation payload.
+@@ -364,14 +362,18 @@
+   ): OrganizationsEdge
+ }
+ 
+-"""All input for the `deleteTeamById` mutation."""
+-input DeleteTeamByIdInput {
++"""All input for the `deleteTeamByNodeId` mutation."""
++input DeleteTeamByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-  id: Int!
++
++  """
++  The globally unique `ID` which will identify a single `Team` to be deleted.
++  """
++  nodeId: ID!
+ }
+ 
+ """All input for the `deleteTeam` mutation."""
+@@ -381,11 +383,7 @@
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-
+-  """
+-  The globally unique `ID` which will identify a single `Team` to be deleted.
+-  """
+-  nodeId: ID!
++  id: Int!
+ }
+ 
+ """The output of our delete `Team` mutation."""
+@@ -398,7 +396,7 @@
+ 
+   """The `Team` that was deleted by this mutation."""
+   team: Team
+-  deletedTeamId: ID
++  deletedTeamNodeId: ID
+ 
+   """
+   Our root query field type. Allows us to run any query from our mutation payload.
+@@ -412,14 +410,18 @@
+   ): TeamsEdge
+ }
+ 
+-"""All input for the `deleteUserById` mutation."""
+-input DeleteUserByIdInput {
++"""All input for the `deleteUserByNodeId` mutation."""
++input DeleteUserByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-  id: Int!
++
++  """
++  The globally unique `ID` which will identify a single `User` to be deleted.
++  """
++  nodeId: ID!
+ }
+ 
+ """All input for the `deleteUser` mutation."""
+@@ -429,11 +431,7 @@
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-
+-  """
+-  The globally unique `ID` which will identify a single `User` to be deleted.
+-  """
+-  nodeId: ID!
++  id: Int!
+ }
+ 
+ """The output of our delete `User` mutation."""
+@@ -446,7 +444,7 @@
+ 
+   """The `User` that was deleted by this mutation."""
+   user: User
+-  deletedUserId: ID
++  deletedUserNodeId: ID
+ 
+   """
+   Our root query field type. Allows us to run any query from our mutation payload.
+@@ -471,10 +469,10 @@
+   aim: String
+ 
+   """Reads a single `Organization` that is related to this `Goal`."""
+-  organizationByOrganizationId: Organization
++  organization: Organization
+ 
+   """Reads a single `Team` that is related to this `Goal`."""
+-  teamByTeamId: Team
++  team: Team
+ 
+   """Reads and enables pagination through a set of `GoalContributor`."""
+   goalContributorsByOrganizationIdAndTeamIdAndGoalUuid(
+@@ -555,16 +553,16 @@
+   """
+   Reads a single `Organization` that is related to this `GoalContributor`.
+   """
+-  organizationByOrganizationId: Organization
++  organization: Organization
+ 
+   """Reads a single `Goal` that is related to this `GoalContributor`."""
+-  goalByOrganizationIdAndTeamIdAndGoalUuid: Goal
++  organizationTeamGoal: Goal
+ 
+   """Reads a single `Team` that is related to this `GoalContributor`."""
+-  teamByTeamId: Team
++  team: Team
+ 
+   """Reads a single `User` that is related to this `GoalContributor`."""
+-  userByContributorId: User
++  contributor: User
+ }
+ 
+ """
+@@ -766,165 +764,165 @@
+   """
+   Updates a single `GoalContributor` using its globally unique id and a patch.
+   """
+-  updateGoalContributor(
++  updateGoalContributorByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateGoalContributorInput!
++    input: UpdateGoalContributorByNodeIdInput!
+   ): UpdateGoalContributorPayload
+ 
+   """Updates a single `GoalContributor` using a unique key and a patch."""
+-  updateGoalContributorById(
++  updateGoalContributor(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateGoalContributorByIdInput!
++    input: UpdateGoalContributorInput!
+   ): UpdateGoalContributorPayload
+ 
+   """Updates a single `Goal` using its globally unique id and a patch."""
+-  updateGoal(
++  updateGoalByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateGoalInput!
++    input: UpdateGoalByNodeIdInput!
+   ): UpdateGoalPayload
+ 
+   """Updates a single `Goal` using a unique key and a patch."""
+-  updateGoalByOrganizationIdAndTeamIdAndGoalUuid(
++  updateGoal(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateGoalByOrganizationIdAndTeamIdAndGoalUuidInput!
++    input: UpdateGoalInput!
+   ): UpdateGoalPayload
+ 
+   """
+   Updates a single `Organization` using its globally unique id and a patch.
+   """
+-  updateOrganization(
++  updateOrganizationByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateOrganizationInput!
++    input: UpdateOrganizationByNodeIdInput!
+   ): UpdateOrganizationPayload
+ 
+   """Updates a single `Organization` using a unique key and a patch."""
+-  updateOrganizationById(
++  updateOrganization(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateOrganizationByIdInput!
++    input: UpdateOrganizationInput!
+   ): UpdateOrganizationPayload
+ 
+   """Updates a single `Team` using its globally unique id and a patch."""
+-  updateTeam(
++  updateTeamByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateTeamInput!
++    input: UpdateTeamByNodeIdInput!
+   ): UpdateTeamPayload
+ 
+   """Updates a single `Team` using a unique key and a patch."""
+-  updateTeamById(
++  updateTeam(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateTeamByIdInput!
++    input: UpdateTeamInput!
+   ): UpdateTeamPayload
+ 
+   """Updates a single `User` using its globally unique id and a patch."""
+-  updateUser(
++  updateUserByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateUserInput!
++    input: UpdateUserByNodeIdInput!
+   ): UpdateUserPayload
+ 
+   """Updates a single `User` using a unique key and a patch."""
+-  updateUserById(
++  updateUser(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateUserByIdInput!
++    input: UpdateUserInput!
+   ): UpdateUserPayload
+ 
+   """Deletes a single `GoalContributor` using its globally unique id."""
+-  deleteGoalContributor(
++  deleteGoalContributorByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteGoalContributorInput!
++    input: DeleteGoalContributorByNodeIdInput!
+   ): DeleteGoalContributorPayload
+ 
+   """Deletes a single `GoalContributor` using a unique key."""
+-  deleteGoalContributorById(
++  deleteGoalContributor(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteGoalContributorByIdInput!
++    input: DeleteGoalContributorInput!
+   ): DeleteGoalContributorPayload
+ 
+   """Deletes a single `Goal` using its globally unique id."""
+-  deleteGoal(
++  deleteGoalByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteGoalInput!
++    input: DeleteGoalByNodeIdInput!
+   ): DeleteGoalPayload
+ 
+   """Deletes a single `Goal` using a unique key."""
+-  deleteGoalByOrganizationIdAndTeamIdAndGoalUuid(
++  deleteGoal(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteGoalByOrganizationIdAndTeamIdAndGoalUuidInput!
++    input: DeleteGoalInput!
+   ): DeleteGoalPayload
+ 
+   """Deletes a single `Organization` using its globally unique id."""
+-  deleteOrganization(
++  deleteOrganizationByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteOrganizationInput!
++    input: DeleteOrganizationByNodeIdInput!
+   ): DeleteOrganizationPayload
+ 
+   """Deletes a single `Organization` using a unique key."""
+-  deleteOrganizationById(
++  deleteOrganization(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteOrganizationByIdInput!
++    input: DeleteOrganizationInput!
+   ): DeleteOrganizationPayload
+ 
+   """Deletes a single `Team` using its globally unique id."""
+-  deleteTeam(
++  deleteTeamByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteTeamInput!
++    input: DeleteTeamByNodeIdInput!
+   ): DeleteTeamPayload
+ 
+   """Deletes a single `Team` using a unique key."""
+-  deleteTeamById(
++  deleteTeam(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteTeamByIdInput!
++    input: DeleteTeamInput!
+   ): DeleteTeamPayload
+ 
+   """Deletes a single `User` using its globally unique id."""
+-  deleteUser(
++  deleteUserByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteUserInput!
++    input: DeleteUserByNodeIdInput!
+   ): DeleteUserPayload
+ 
+   """Deletes a single `User` using a unique key."""
+-  deleteUserById(
++  deleteUser(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteUserByIdInput!
++    input: DeleteUserInput!
+   ): DeleteUserPayload
+ }
+ 
+@@ -945,7 +943,7 @@
+   name: String
+ 
+   """Reads and enables pagination through a set of `Goal`."""
+-  goalsByOrganizationId(
++  goals(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -974,7 +972,7 @@
+   ): GoalsConnection!
+ 
+   """Reads and enables pagination through a set of `Goal`."""
+-  goalsByOrganizationIdList(
++  goalsList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -991,7 +989,7 @@
+   ): [Goal!]!
+ 
+   """Reads and enables pagination through a set of `GoalContributor`."""
+-  goalContributorsByOrganizationId(
++  goalContributors(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1020,7 +1018,7 @@
+   ): GoalContributorsConnection!
+ 
+   """Reads and enables pagination through a set of `GoalContributor`."""
+-  goalContributorsByOrganizationIdList(
++  goalContributorsList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1135,7 +1133,7 @@
+   ): Node
+ 
+   """Reads and enables pagination through a set of `GoalContributor`."""
+-  allGoalContributors(
++  goalContributors(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1164,7 +1162,7 @@
+   ): GoalContributorsConnection
+ 
+   """Reads a set of `GoalContributor`."""
+-  allGoalContributorsList(
++  goalContributorsList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1181,7 +1179,7 @@
+   ): [GoalContributor!]
+ 
+   """Reads and enables pagination through a set of `Goal`."""
+-  allGoals(
++  goals(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1210,7 +1208,7 @@
+   ): GoalsConnection
+ 
+   """Reads a set of `Goal`."""
+-  allGoalsList(
++  goalsList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1227,7 +1225,7 @@
+   ): [Goal!]
+ 
+   """Reads and enables pagination through a set of `Organization`."""
+-  allOrganizations(
++  organizations(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1256,7 +1254,7 @@
+   ): OrganizationsConnection
+ 
+   """Reads a set of `Organization`."""
+-  allOrganizationsList(
++  organizationsList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1273,7 +1271,7 @@
+   ): [Organization!]
+ 
+   """Reads and enables pagination through a set of `Team`."""
+-  allTeams(
++  teams(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1302,7 +1300,7 @@
+   ): TeamsConnection
+ 
+   """Reads a set of `Team`."""
+-  allTeamsList(
++  teamsList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1319,7 +1317,7 @@
+   ): [Team!]
+ 
+   """Reads and enables pagination through a set of `User`."""
+-  allUsers(
++  users(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1348,7 +1346,7 @@
+   ): UsersConnection
+ 
+   """Reads a set of `User`."""
+-  allUsersList(
++  usersList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1363,14 +1361,14 @@
+     """
+     condition: UserCondition
+   ): [User!]
+-  goalContributorById(id: Int!): GoalContributor
+-  goalByOrganizationIdAndTeamIdAndGoalUuid(organizationId: Int!, teamId: Int!, goalUuid: UUID!): Goal
+-  organizationById(id: Int!): Organization
+-  teamById(id: Int!): Team
+-  userById(id: Int!): User
++  goalContributor(id: Int!): GoalContributor
++  goal(organizationId: Int!, teamId: Int!, goalUuid: UUID!): Goal
++  organization(id: Int!): Organization
++  team(id: Int!): Team
++  user(id: Int!): User
+ 
+   """Reads a single `GoalContributor` using its globally unique `ID`."""
+-  goalContributor(
++  goalContributorByNodeId(
+     """
+     The globally unique `ID` to be used in selecting a single `GoalContributor`.
+     """
+@@ -1378,13 +1376,13 @@
+   ): GoalContributor
+ 
+   """Reads a single `Goal` using its globally unique `ID`."""
+-  goal(
++  goalByNodeId(
+     """The globally unique `ID` to be used in selecting a single `Goal`."""
+     nodeId: ID!
+   ): Goal
+ 
+   """Reads a single `Organization` using its globally unique `ID`."""
+-  organization(
++  organizationByNodeId(
+     """
+     The globally unique `ID` to be used in selecting a single `Organization`.
+     """
+@@ -1392,13 +1390,13 @@
+   ): Organization
+ 
+   """Reads a single `Team` using its globally unique `ID`."""
+-  team(
++  teamByNodeId(
+     """The globally unique `ID` to be used in selecting a single `Team`."""
+     nodeId: ID!
+   ): Team
+ 
+   """Reads a single `User` using its globally unique `ID`."""
+-  user(
++  userByNodeId(
+     """The globally unique `ID` to be used in selecting a single `User`."""
+     nodeId: ID!
+   ): User
+@@ -1413,7 +1411,7 @@
+   name: String
+ 
+   """Reads and enables pagination through a set of `Goal`."""
+-  goalsByTeamId(
++  goals(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1442,7 +1440,7 @@
+   ): GoalsConnection!
+ 
+   """Reads and enables pagination through a set of `Goal`."""
+-  goalsByTeamIdList(
++  goalsList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1459,7 +1457,7 @@
+   ): [Goal!]!
+ 
+   """Reads and enables pagination through a set of `GoalContributor`."""
+-  goalContributorsByTeamId(
++  goalContributors(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1488,7 +1486,7 @@
+   ): GoalContributorsConnection!
+ 
+   """Reads and enables pagination through a set of `GoalContributor`."""
+-  goalContributorsByTeamIdList(
++  goalContributorsList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1567,10 +1565,8 @@
+   PRIMARY_KEY_DESC
+ }
+ 
+-"""
+-All input for the `updateGoalByOrganizationIdAndTeamIdAndGoalUuid` mutation.
+-"""
+-input UpdateGoalByOrganizationIdAndTeamIdAndGoalUuidInput {
++"""All input for the `updateGoalByNodeId` mutation."""
++input UpdateGoalByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+@@ -1578,16 +1574,18 @@
+   clientMutationId: String
+ 
+   """
++  The globally unique `ID` which will identify a single `Goal` to be updated.
++  """
++  nodeId: ID!
++
++  """
+   An object where the defined keys will be set on the `Goal` being updated.
+   """
+-  goalPatch: GoalPatch!
+-  organizationId: Int!
+-  teamId: Int!
+-  goalUuid: UUID!
++  patch: GoalPatch!
+ }
+ 
+-"""All input for the `updateGoalContributorById` mutation."""
+-input UpdateGoalContributorByIdInput {
++"""All input for the `updateGoalContributorByNodeId` mutation."""
++input UpdateGoalContributorByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+@@ -1595,10 +1593,14 @@
+   clientMutationId: String
+ 
+   """
++  The globally unique `ID` which will identify a single `GoalContributor` to be updated.
++  """
++  nodeId: ID!
++
++  """
+   An object where the defined keys will be set on the `GoalContributor` being updated.
+   """
+-  goalContributorPatch: GoalContributorPatch!
+-  id: Int!
++  patch: GoalContributorPatch!
+ }
+ 
+ """All input for the `updateGoalContributor` mutation."""
+@@ -1610,14 +1612,10 @@
+   clientMutationId: String
+ 
+   """
+-  The globally unique `ID` which will identify a single `GoalContributor` to be updated.
+-  """
+-  nodeId: ID!
+-
+-  """
+   An object where the defined keys will be set on the `GoalContributor` being updated.
+   """
+-  goalContributorPatch: GoalContributorPatch!
++  patch: GoalContributorPatch!
++  id: Int!
+ }
+ 
+ """The output of our update `GoalContributor` mutation."""
+@@ -1639,16 +1637,16 @@
+   """
+   Reads a single `Organization` that is related to this `GoalContributor`.
+   """
+-  organizationByOrganizationId: Organization
++  organization: Organization
+ 
+   """Reads a single `Goal` that is related to this `GoalContributor`."""
+-  goalByOrganizationIdAndTeamIdAndGoalUuid: Goal
++  organizationTeamGoal: Goal
+ 
+   """Reads a single `Team` that is related to this `GoalContributor`."""
+-  teamByTeamId: Team
++  team: Team
+ 
+   """Reads a single `User` that is related to this `GoalContributor`."""
+-  userByContributorId: User
++  contributor: User
+ 
+   """An edge for our `GoalContributor`. May be used by Relay 1."""
+   goalContributorEdge(
+@@ -1666,14 +1664,12 @@
+   clientMutationId: String
+ 
+   """
+-  The globally unique `ID` which will identify a single `Goal` to be updated.
+-  """
+-  nodeId: ID!
+-
+-  """
+   An object where the defined keys will be set on the `Goal` being updated.
+   """
+-  goalPatch: GoalPatch!
++  patch: GoalPatch!
++  organizationId: Int!
++  teamId: Int!
++  goalUuid: UUID!
+ }
+ 
+ """The output of our update `Goal` mutation."""
+@@ -1693,10 +1689,10 @@
+   query: Query
+ 
+   """Reads a single `Organization` that is related to this `Goal`."""
+-  organizationByOrganizationId: Organization
++  organization: Organization
+ 
+   """Reads a single `Team` that is related to this `Goal`."""
+-  teamByTeamId: Team
++  team: Team
+ 
+   """An edge for our `Goal`. May be used by Relay 1."""
+   goalEdge(
+@@ -1705,8 +1701,8 @@
+   ): GoalsEdge
+ }
+ 
+-"""All input for the `updateOrganizationById` mutation."""
+-input UpdateOrganizationByIdInput {
++"""All input for the `updateOrganizationByNodeId` mutation."""
++input UpdateOrganizationByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+@@ -1714,10 +1710,14 @@
+   clientMutationId: String
+ 
+   """
++  The globally unique `ID` which will identify a single `Organization` to be updated.
++  """
++  nodeId: ID!
++
++  """
+   An object where the defined keys will be set on the `Organization` being updated.
+   """
+-  organizationPatch: OrganizationPatch!
+-  id: Int!
++  patch: OrganizationPatch!
+ }
+ 
+ """All input for the `updateOrganization` mutation."""
+@@ -1729,14 +1729,10 @@
+   clientMutationId: String
+ 
+   """
+-  The globally unique `ID` which will identify a single `Organization` to be updated.
+-  """
+-  nodeId: ID!
+-
+-  """
+   An object where the defined keys will be set on the `Organization` being updated.
+   """
+-  organizationPatch: OrganizationPatch!
++  patch: OrganizationPatch!
++  id: Int!
+ }
+ 
+ """The output of our update `Organization` mutation."""
+@@ -1762,8 +1758,8 @@
+   ): OrganizationsEdge
+ }
+ 
+-"""All input for the `updateTeamById` mutation."""
+-input UpdateTeamByIdInput {
++"""All input for the `updateTeamByNodeId` mutation."""
++input UpdateTeamByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+@@ -1771,10 +1767,14 @@
+   clientMutationId: String
+ 
+   """
++  The globally unique `ID` which will identify a single `Team` to be updated.
++  """
++  nodeId: ID!
++
++  """
+   An object where the defined keys will be set on the `Team` being updated.
+   """
+-  teamPatch: TeamPatch!
+-  id: Int!
++  patch: TeamPatch!
+ }
+ 
+ """All input for the `updateTeam` mutation."""
+@@ -1786,14 +1786,10 @@
+   clientMutationId: String
+ 
+   """
+-  The globally unique `ID` which will identify a single `Team` to be updated.
+-  """
+-  nodeId: ID!
+-
+-  """
+   An object where the defined keys will be set on the `Team` being updated.
+   """
+-  teamPatch: TeamPatch!
++  patch: TeamPatch!
++  id: Int!
+ }
+ 
+ """The output of our update `Team` mutation."""
+@@ -1819,8 +1815,8 @@
+   ): TeamsEdge
+ }
+ 
+-"""All input for the `updateUserById` mutation."""
+-input UpdateUserByIdInput {
++"""All input for the `updateUserByNodeId` mutation."""
++input UpdateUserByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+@@ -1828,10 +1824,14 @@
+   clientMutationId: String
+ 
+   """
++  The globally unique `ID` which will identify a single `User` to be updated.
++  """
++  nodeId: ID!
++
++  """
+   An object where the defined keys will be set on the `User` being updated.
+   """
+-  userPatch: UserPatch!
+-  id: Int!
++  patch: UserPatch!
+ }
+ 
+ """All input for the `updateUser` mutation."""
+@@ -1843,14 +1843,10 @@
+   clientMutationId: String
+ 
+   """
+-  The globally unique `ID` which will identify a single `User` to be updated.
+-  """
+-  nodeId: ID!
+-
+-  """
+   An object where the defined keys will be set on the `User` being updated.
+   """
+-  userPatch: UserPatch!
++  patch: UserPatch!
++  id: Int!
+ }
+ 
+ """The output of our update `User` mutation."""

--- a/tests/multikey_refs/schema.graphql.diff
+++ b/tests/multikey_refs/schema.graphql.diff
@@ -1,5 +1,5 @@
---- /home/benjie/Dev/graphile/pg-simplify-inflector/tests/multikey_refs/schema.unsimplified.graphql	2020-04-14 12:28:00.530919438 +0100
-+++ /home/benjie/Dev/graphile/pg-simplify-inflector/tests/multikey_refs/schema.simplified.graphql	2020-04-14 12:28:00.530919438 +0100
+--- unsimplified
++++ simplified
 @@ -29,16 +29,16 @@
    """
    Reads a single `Organization` that is related to this `GoalContributor`.

--- a/tests/multikey_refs/schema.simplified.graphql
+++ b/tests/multikey_refs/schema.simplified.graphql
@@ -1,0 +1,1995 @@
+"""All input for the create `GoalContributor` mutation."""
+input CreateGoalContributorInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `GoalContributor` to be created by this mutation."""
+  goalContributor: GoalContributorInput!
+}
+
+"""The output of our create `GoalContributor` mutation."""
+type CreateGoalContributorPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `GoalContributor` that was created by this mutation."""
+  goalContributor: GoalContributor
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """
+  Reads a single `Organization` that is related to this `GoalContributor`.
+  """
+  organization: Organization
+
+  """Reads a single `Goal` that is related to this `GoalContributor`."""
+  organizationTeamGoal: Goal
+
+  """Reads a single `Team` that is related to this `GoalContributor`."""
+  team: Team
+
+  """Reads a single `User` that is related to this `GoalContributor`."""
+  contributor: User
+
+  """An edge for our `GoalContributor`. May be used by Relay 1."""
+  goalContributorEdge(
+    """The method to use when ordering `GoalContributor`."""
+    orderBy: [GoalContributorsOrderBy!] = PRIMARY_KEY_ASC
+  ): GoalContributorsEdge
+}
+
+"""All input for the create `Goal` mutation."""
+input CreateGoalInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `Goal` to be created by this mutation."""
+  goal: GoalInput!
+}
+
+"""The output of our create `Goal` mutation."""
+type CreateGoalPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Goal` that was created by this mutation."""
+  goal: Goal
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single `Organization` that is related to this `Goal`."""
+  organization: Organization
+
+  """Reads a single `Team` that is related to this `Goal`."""
+  team: Team
+
+  """An edge for our `Goal`. May be used by Relay 1."""
+  goalEdge(
+    """The method to use when ordering `Goal`."""
+    orderBy: [GoalsOrderBy!] = PRIMARY_KEY_ASC
+  ): GoalsEdge
+}
+
+"""All input for the create `Organization` mutation."""
+input CreateOrganizationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `Organization` to be created by this mutation."""
+  organization: OrganizationInput!
+}
+
+"""The output of our create `Organization` mutation."""
+type CreateOrganizationPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Organization` that was created by this mutation."""
+  organization: Organization
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `Organization`. May be used by Relay 1."""
+  organizationEdge(
+    """The method to use when ordering `Organization`."""
+    orderBy: [OrganizationsOrderBy!] = PRIMARY_KEY_ASC
+  ): OrganizationsEdge
+}
+
+"""All input for the create `Team` mutation."""
+input CreateTeamInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `Team` to be created by this mutation."""
+  team: TeamInput!
+}
+
+"""The output of our create `Team` mutation."""
+type CreateTeamPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Team` that was created by this mutation."""
+  team: Team
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `Team`. May be used by Relay 1."""
+  teamEdge(
+    """The method to use when ordering `Team`."""
+    orderBy: [TeamsOrderBy!] = PRIMARY_KEY_ASC
+  ): TeamsEdge
+}
+
+"""All input for the create `User` mutation."""
+input CreateUserInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `User` to be created by this mutation."""
+  user: UserInput!
+}
+
+"""The output of our create `User` mutation."""
+type CreateUserPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `User` that was created by this mutation."""
+  user: User
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `User`. May be used by Relay 1."""
+  userEdge(
+    """The method to use when ordering `User`."""
+    orderBy: [UsersOrderBy!] = PRIMARY_KEY_ASC
+  ): UsersEdge
+}
+
+"""A location in a connection that can be used for resuming pagination."""
+scalar Cursor
+
+"""All input for the `deleteGoalByNodeId` mutation."""
+input DeleteGoalByNodeIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Goal` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""All input for the `deleteGoalContributorByNodeId` mutation."""
+input DeleteGoalContributorByNodeIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `GoalContributor` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""All input for the `deleteGoalContributor` mutation."""
+input DeleteGoalContributorInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""The output of our delete `GoalContributor` mutation."""
+type DeleteGoalContributorPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `GoalContributor` that was deleted by this mutation."""
+  goalContributor: GoalContributor
+  deletedGoalContributorNodeId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """
+  Reads a single `Organization` that is related to this `GoalContributor`.
+  """
+  organization: Organization
+
+  """Reads a single `Goal` that is related to this `GoalContributor`."""
+  organizationTeamGoal: Goal
+
+  """Reads a single `Team` that is related to this `GoalContributor`."""
+  team: Team
+
+  """Reads a single `User` that is related to this `GoalContributor`."""
+  contributor: User
+
+  """An edge for our `GoalContributor`. May be used by Relay 1."""
+  goalContributorEdge(
+    """The method to use when ordering `GoalContributor`."""
+    orderBy: [GoalContributorsOrderBy!] = PRIMARY_KEY_ASC
+  ): GoalContributorsEdge
+}
+
+"""All input for the `deleteGoal` mutation."""
+input DeleteGoalInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  organizationId: Int!
+  teamId: Int!
+  goalUuid: UUID!
+}
+
+"""The output of our delete `Goal` mutation."""
+type DeleteGoalPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Goal` that was deleted by this mutation."""
+  goal: Goal
+  deletedGoalNodeId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single `Organization` that is related to this `Goal`."""
+  organization: Organization
+
+  """Reads a single `Team` that is related to this `Goal`."""
+  team: Team
+
+  """An edge for our `Goal`. May be used by Relay 1."""
+  goalEdge(
+    """The method to use when ordering `Goal`."""
+    orderBy: [GoalsOrderBy!] = PRIMARY_KEY_ASC
+  ): GoalsEdge
+}
+
+"""All input for the `deleteOrganizationByNodeId` mutation."""
+input DeleteOrganizationByNodeIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Organization` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""All input for the `deleteOrganization` mutation."""
+input DeleteOrganizationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""The output of our delete `Organization` mutation."""
+type DeleteOrganizationPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Organization` that was deleted by this mutation."""
+  organization: Organization
+  deletedOrganizationNodeId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `Organization`. May be used by Relay 1."""
+  organizationEdge(
+    """The method to use when ordering `Organization`."""
+    orderBy: [OrganizationsOrderBy!] = PRIMARY_KEY_ASC
+  ): OrganizationsEdge
+}
+
+"""All input for the `deleteTeamByNodeId` mutation."""
+input DeleteTeamByNodeIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Team` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""All input for the `deleteTeam` mutation."""
+input DeleteTeamInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""The output of our delete `Team` mutation."""
+type DeleteTeamPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Team` that was deleted by this mutation."""
+  team: Team
+  deletedTeamNodeId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `Team`. May be used by Relay 1."""
+  teamEdge(
+    """The method to use when ordering `Team`."""
+    orderBy: [TeamsOrderBy!] = PRIMARY_KEY_ASC
+  ): TeamsEdge
+}
+
+"""All input for the `deleteUserByNodeId` mutation."""
+input DeleteUserByNodeIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `User` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""All input for the `deleteUser` mutation."""
+input DeleteUserInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""The output of our delete `User` mutation."""
+type DeleteUserPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `User` that was deleted by this mutation."""
+  user: User
+  deletedUserNodeId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `User`. May be used by Relay 1."""
+  userEdge(
+    """The method to use when ordering `User`."""
+    orderBy: [UsersOrderBy!] = PRIMARY_KEY_ASC
+  ): UsersEdge
+}
+
+type Goal implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  organizationId: Int!
+  teamId: Int!
+  goalUuid: UUID!
+  aim: String
+
+  """Reads a single `Organization` that is related to this `Goal`."""
+  organization: Organization
+
+  """Reads a single `Team` that is related to this `Goal`."""
+  team: Team
+
+  """Reads and enables pagination through a set of `GoalContributor`."""
+  goalContributorsByOrganizationIdAndTeamIdAndGoalUuid(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `GoalContributor`."""
+    orderBy: [GoalContributorsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalContributorCondition
+  ): GoalContributorsConnection!
+
+  """Reads and enables pagination through a set of `GoalContributor`."""
+  goalContributorsByOrganizationIdAndTeamIdAndGoalUuidList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `GoalContributor`."""
+    orderBy: [GoalContributorsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalContributorCondition
+  ): [GoalContributor!]!
+}
+
+"""
+A condition to be used against `Goal` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input GoalCondition {
+  """Checks for equality with the object’s `organizationId` field."""
+  organizationId: Int
+
+  """Checks for equality with the object’s `teamId` field."""
+  teamId: Int
+
+  """Checks for equality with the object’s `goalUuid` field."""
+  goalUuid: UUID
+
+  """Checks for equality with the object’s `aim` field."""
+  aim: String
+}
+
+type GoalContributor implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  organizationId: Int!
+  teamId: Int!
+  goalUuid: UUID!
+  contributorId: Int!
+  contribution: String
+
+  """
+  Reads a single `Organization` that is related to this `GoalContributor`.
+  """
+  organization: Organization
+
+  """Reads a single `Goal` that is related to this `GoalContributor`."""
+  organizationTeamGoal: Goal
+
+  """Reads a single `Team` that is related to this `GoalContributor`."""
+  team: Team
+
+  """Reads a single `User` that is related to this `GoalContributor`."""
+  contributor: User
+}
+
+"""
+A condition to be used against `GoalContributor` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input GoalContributorCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `organizationId` field."""
+  organizationId: Int
+
+  """Checks for equality with the object’s `teamId` field."""
+  teamId: Int
+
+  """Checks for equality with the object’s `goalUuid` field."""
+  goalUuid: UUID
+
+  """Checks for equality with the object’s `contributorId` field."""
+  contributorId: Int
+
+  """Checks for equality with the object’s `contribution` field."""
+  contribution: String
+}
+
+"""An input for mutations affecting `GoalContributor`"""
+input GoalContributorInput {
+  id: Int
+  organizationId: Int!
+  teamId: Int!
+  goalUuid: UUID!
+  contributorId: Int!
+  contribution: String
+}
+
+"""
+Represents an update to a `GoalContributor`. Fields that are set will be updated.
+"""
+input GoalContributorPatch {
+  id: Int
+  organizationId: Int
+  teamId: Int
+  goalUuid: UUID
+  contributorId: Int
+  contribution: String
+}
+
+"""A connection to a list of `GoalContributor` values."""
+type GoalContributorsConnection {
+  """A list of `GoalContributor` objects."""
+  nodes: [GoalContributor]!
+
+  """
+  A list of edges which contains the `GoalContributor` and cursor to aid in pagination.
+  """
+  edges: [GoalContributorsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `GoalContributor` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+"""A `GoalContributor` edge in the connection."""
+type GoalContributorsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `GoalContributor` at the end of the edge."""
+  node: GoalContributor
+}
+
+"""Methods to use when ordering `GoalContributor`."""
+enum GoalContributorsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  ORGANIZATION_ID_ASC
+  ORGANIZATION_ID_DESC
+  TEAM_ID_ASC
+  TEAM_ID_DESC
+  GOAL_UUID_ASC
+  GOAL_UUID_DESC
+  CONTRIBUTOR_ID_ASC
+  CONTRIBUTOR_ID_DESC
+  CONTRIBUTION_ASC
+  CONTRIBUTION_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""An input for mutations affecting `Goal`"""
+input GoalInput {
+  organizationId: Int!
+  teamId: Int!
+  goalUuid: UUID
+  aim: String
+}
+
+"""
+Represents an update to a `Goal`. Fields that are set will be updated.
+"""
+input GoalPatch {
+  organizationId: Int
+  teamId: Int
+  goalUuid: UUID
+  aim: String
+}
+
+"""A connection to a list of `Goal` values."""
+type GoalsConnection {
+  """A list of `Goal` objects."""
+  nodes: [Goal]!
+
+  """
+  A list of edges which contains the `Goal` and cursor to aid in pagination.
+  """
+  edges: [GoalsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Goal` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Goal` edge in the connection."""
+type GoalsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Goal` at the end of the edge."""
+  node: Goal
+}
+
+"""Methods to use when ordering `Goal`."""
+enum GoalsOrderBy {
+  NATURAL
+  ORGANIZATION_ID_ASC
+  ORGANIZATION_ID_DESC
+  TEAM_ID_ASC
+  TEAM_ID_DESC
+  GOAL_UUID_ASC
+  GOAL_UUID_DESC
+  AIM_ASC
+  AIM_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+The root mutation type which contains root level fields which mutate data.
+"""
+type Mutation {
+  """Creates a single `GoalContributor`."""
+  createGoalContributor(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateGoalContributorInput!
+  ): CreateGoalContributorPayload
+
+  """Creates a single `Goal`."""
+  createGoal(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateGoalInput!
+  ): CreateGoalPayload
+
+  """Creates a single `Organization`."""
+  createOrganization(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateOrganizationInput!
+  ): CreateOrganizationPayload
+
+  """Creates a single `Team`."""
+  createTeam(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateTeamInput!
+  ): CreateTeamPayload
+
+  """Creates a single `User`."""
+  createUser(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateUserInput!
+  ): CreateUserPayload
+
+  """
+  Updates a single `GoalContributor` using its globally unique id and a patch.
+  """
+  updateGoalContributorByNodeId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateGoalContributorByNodeIdInput!
+  ): UpdateGoalContributorPayload
+
+  """Updates a single `GoalContributor` using a unique key and a patch."""
+  updateGoalContributor(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateGoalContributorInput!
+  ): UpdateGoalContributorPayload
+
+  """Updates a single `Goal` using its globally unique id and a patch."""
+  updateGoalByNodeId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateGoalByNodeIdInput!
+  ): UpdateGoalPayload
+
+  """Updates a single `Goal` using a unique key and a patch."""
+  updateGoal(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateGoalInput!
+  ): UpdateGoalPayload
+
+  """
+  Updates a single `Organization` using its globally unique id and a patch.
+  """
+  updateOrganizationByNodeId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateOrganizationByNodeIdInput!
+  ): UpdateOrganizationPayload
+
+  """Updates a single `Organization` using a unique key and a patch."""
+  updateOrganization(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateOrganizationInput!
+  ): UpdateOrganizationPayload
+
+  """Updates a single `Team` using its globally unique id and a patch."""
+  updateTeamByNodeId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateTeamByNodeIdInput!
+  ): UpdateTeamPayload
+
+  """Updates a single `Team` using a unique key and a patch."""
+  updateTeam(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateTeamInput!
+  ): UpdateTeamPayload
+
+  """Updates a single `User` using its globally unique id and a patch."""
+  updateUserByNodeId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateUserByNodeIdInput!
+  ): UpdateUserPayload
+
+  """Updates a single `User` using a unique key and a patch."""
+  updateUser(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateUserInput!
+  ): UpdateUserPayload
+
+  """Deletes a single `GoalContributor` using its globally unique id."""
+  deleteGoalContributorByNodeId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteGoalContributorByNodeIdInput!
+  ): DeleteGoalContributorPayload
+
+  """Deletes a single `GoalContributor` using a unique key."""
+  deleteGoalContributor(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteGoalContributorInput!
+  ): DeleteGoalContributorPayload
+
+  """Deletes a single `Goal` using its globally unique id."""
+  deleteGoalByNodeId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteGoalByNodeIdInput!
+  ): DeleteGoalPayload
+
+  """Deletes a single `Goal` using a unique key."""
+  deleteGoal(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteGoalInput!
+  ): DeleteGoalPayload
+
+  """Deletes a single `Organization` using its globally unique id."""
+  deleteOrganizationByNodeId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteOrganizationByNodeIdInput!
+  ): DeleteOrganizationPayload
+
+  """Deletes a single `Organization` using a unique key."""
+  deleteOrganization(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteOrganizationInput!
+  ): DeleteOrganizationPayload
+
+  """Deletes a single `Team` using its globally unique id."""
+  deleteTeamByNodeId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteTeamByNodeIdInput!
+  ): DeleteTeamPayload
+
+  """Deletes a single `Team` using a unique key."""
+  deleteTeam(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteTeamInput!
+  ): DeleteTeamPayload
+
+  """Deletes a single `User` using its globally unique id."""
+  deleteUserByNodeId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteUserByNodeIdInput!
+  ): DeleteUserPayload
+
+  """Deletes a single `User` using a unique key."""
+  deleteUser(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteUserInput!
+  ): DeleteUserPayload
+}
+
+"""An object with a globally unique `ID`."""
+interface Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+type Organization implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  name: String
+
+  """Reads and enables pagination through a set of `Goal`."""
+  goals(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Goal`."""
+    orderBy: [GoalsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalCondition
+  ): GoalsConnection!
+
+  """Reads and enables pagination through a set of `Goal`."""
+  goalsList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Goal`."""
+    orderBy: [GoalsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalCondition
+  ): [Goal!]!
+
+  """Reads and enables pagination through a set of `GoalContributor`."""
+  goalContributors(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `GoalContributor`."""
+    orderBy: [GoalContributorsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalContributorCondition
+  ): GoalContributorsConnection!
+
+  """Reads and enables pagination through a set of `GoalContributor`."""
+  goalContributorsList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `GoalContributor`."""
+    orderBy: [GoalContributorsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalContributorCondition
+  ): [GoalContributor!]!
+}
+
+"""
+A condition to be used against `Organization` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input OrganizationCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `name` field."""
+  name: String
+}
+
+"""An input for mutations affecting `Organization`"""
+input OrganizationInput {
+  id: Int
+  name: String
+}
+
+"""
+Represents an update to a `Organization`. Fields that are set will be updated.
+"""
+input OrganizationPatch {
+  id: Int
+  name: String
+}
+
+"""A connection to a list of `Organization` values."""
+type OrganizationsConnection {
+  """A list of `Organization` objects."""
+  nodes: [Organization]!
+
+  """
+  A list of edges which contains the `Organization` and cursor to aid in pagination.
+  """
+  edges: [OrganizationsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Organization` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Organization` edge in the connection."""
+type OrganizationsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Organization` at the end of the edge."""
+  node: Organization
+}
+
+"""Methods to use when ordering `Organization`."""
+enum OrganizationsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: Cursor
+
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+}
+
+"""The root query type which gives access points into the data universe."""
+type Query implements Node {
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
+
+  """
+  The root query type must be a `Node` to work well with Relay 1 mutations. This just resolves to `query`.
+  """
+  nodeId: ID!
+
+  """Fetches an object given its globally unique `ID`."""
+  node(
+    """The globally unique `ID`."""
+    nodeId: ID!
+  ): Node
+
+  """Reads and enables pagination through a set of `GoalContributor`."""
+  goalContributors(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `GoalContributor`."""
+    orderBy: [GoalContributorsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalContributorCondition
+  ): GoalContributorsConnection
+
+  """Reads a set of `GoalContributor`."""
+  goalContributorsList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `GoalContributor`."""
+    orderBy: [GoalContributorsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalContributorCondition
+  ): [GoalContributor!]
+
+  """Reads and enables pagination through a set of `Goal`."""
+  goals(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Goal`."""
+    orderBy: [GoalsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalCondition
+  ): GoalsConnection
+
+  """Reads a set of `Goal`."""
+  goalsList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Goal`."""
+    orderBy: [GoalsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalCondition
+  ): [Goal!]
+
+  """Reads and enables pagination through a set of `Organization`."""
+  organizations(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Organization`."""
+    orderBy: [OrganizationsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: OrganizationCondition
+  ): OrganizationsConnection
+
+  """Reads a set of `Organization`."""
+  organizationsList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Organization`."""
+    orderBy: [OrganizationsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: OrganizationCondition
+  ): [Organization!]
+
+  """Reads and enables pagination through a set of `Team`."""
+  teams(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Team`."""
+    orderBy: [TeamsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TeamCondition
+  ): TeamsConnection
+
+  """Reads a set of `Team`."""
+  teamsList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Team`."""
+    orderBy: [TeamsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TeamCondition
+  ): [Team!]
+
+  """Reads and enables pagination through a set of `User`."""
+  users(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `User`."""
+    orderBy: [UsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: UserCondition
+  ): UsersConnection
+
+  """Reads a set of `User`."""
+  usersList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `User`."""
+    orderBy: [UsersOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: UserCondition
+  ): [User!]
+  goalContributor(id: Int!): GoalContributor
+  goal(organizationId: Int!, teamId: Int!, goalUuid: UUID!): Goal
+  organization(id: Int!): Organization
+  team(id: Int!): Team
+  user(id: Int!): User
+
+  """Reads a single `GoalContributor` using its globally unique `ID`."""
+  goalContributorByNodeId(
+    """
+    The globally unique `ID` to be used in selecting a single `GoalContributor`.
+    """
+    nodeId: ID!
+  ): GoalContributor
+
+  """Reads a single `Goal` using its globally unique `ID`."""
+  goalByNodeId(
+    """The globally unique `ID` to be used in selecting a single `Goal`."""
+    nodeId: ID!
+  ): Goal
+
+  """Reads a single `Organization` using its globally unique `ID`."""
+  organizationByNodeId(
+    """
+    The globally unique `ID` to be used in selecting a single `Organization`.
+    """
+    nodeId: ID!
+  ): Organization
+
+  """Reads a single `Team` using its globally unique `ID`."""
+  teamByNodeId(
+    """The globally unique `ID` to be used in selecting a single `Team`."""
+    nodeId: ID!
+  ): Team
+
+  """Reads a single `User` using its globally unique `ID`."""
+  userByNodeId(
+    """The globally unique `ID` to be used in selecting a single `User`."""
+    nodeId: ID!
+  ): User
+}
+
+type Team implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  name: String
+
+  """Reads and enables pagination through a set of `Goal`."""
+  goals(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Goal`."""
+    orderBy: [GoalsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalCondition
+  ): GoalsConnection!
+
+  """Reads and enables pagination through a set of `Goal`."""
+  goalsList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Goal`."""
+    orderBy: [GoalsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalCondition
+  ): [Goal!]!
+
+  """Reads and enables pagination through a set of `GoalContributor`."""
+  goalContributors(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `GoalContributor`."""
+    orderBy: [GoalContributorsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalContributorCondition
+  ): GoalContributorsConnection!
+
+  """Reads and enables pagination through a set of `GoalContributor`."""
+  goalContributorsList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `GoalContributor`."""
+    orderBy: [GoalContributorsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalContributorCondition
+  ): [GoalContributor!]!
+}
+
+"""
+A condition to be used against `Team` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input TeamCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `name` field."""
+  name: String
+}
+
+"""An input for mutations affecting `Team`"""
+input TeamInput {
+  id: Int
+  name: String
+}
+
+"""
+Represents an update to a `Team`. Fields that are set will be updated.
+"""
+input TeamPatch {
+  id: Int
+  name: String
+}
+
+"""A connection to a list of `Team` values."""
+type TeamsConnection {
+  """A list of `Team` objects."""
+  nodes: [Team]!
+
+  """
+  A list of edges which contains the `Team` and cursor to aid in pagination.
+  """
+  edges: [TeamsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Team` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Team` edge in the connection."""
+type TeamsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Team` at the end of the edge."""
+  node: Team
+}
+
+"""Methods to use when ordering `Team`."""
+enum TeamsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""All input for the `updateGoalByNodeId` mutation."""
+input UpdateGoalByNodeIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Goal` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the `Goal` being updated.
+  """
+  patch: GoalPatch!
+}
+
+"""All input for the `updateGoalContributorByNodeId` mutation."""
+input UpdateGoalContributorByNodeIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `GoalContributor` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the `GoalContributor` being updated.
+  """
+  patch: GoalContributorPatch!
+}
+
+"""All input for the `updateGoalContributor` mutation."""
+input UpdateGoalContributorInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `GoalContributor` being updated.
+  """
+  patch: GoalContributorPatch!
+  id: Int!
+}
+
+"""The output of our update `GoalContributor` mutation."""
+type UpdateGoalContributorPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `GoalContributor` that was updated by this mutation."""
+  goalContributor: GoalContributor
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """
+  Reads a single `Organization` that is related to this `GoalContributor`.
+  """
+  organization: Organization
+
+  """Reads a single `Goal` that is related to this `GoalContributor`."""
+  organizationTeamGoal: Goal
+
+  """Reads a single `Team` that is related to this `GoalContributor`."""
+  team: Team
+
+  """Reads a single `User` that is related to this `GoalContributor`."""
+  contributor: User
+
+  """An edge for our `GoalContributor`. May be used by Relay 1."""
+  goalContributorEdge(
+    """The method to use when ordering `GoalContributor`."""
+    orderBy: [GoalContributorsOrderBy!] = PRIMARY_KEY_ASC
+  ): GoalContributorsEdge
+}
+
+"""All input for the `updateGoal` mutation."""
+input UpdateGoalInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Goal` being updated.
+  """
+  patch: GoalPatch!
+  organizationId: Int!
+  teamId: Int!
+  goalUuid: UUID!
+}
+
+"""The output of our update `Goal` mutation."""
+type UpdateGoalPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Goal` that was updated by this mutation."""
+  goal: Goal
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single `Organization` that is related to this `Goal`."""
+  organization: Organization
+
+  """Reads a single `Team` that is related to this `Goal`."""
+  team: Team
+
+  """An edge for our `Goal`. May be used by Relay 1."""
+  goalEdge(
+    """The method to use when ordering `Goal`."""
+    orderBy: [GoalsOrderBy!] = PRIMARY_KEY_ASC
+  ): GoalsEdge
+}
+
+"""All input for the `updateOrganizationByNodeId` mutation."""
+input UpdateOrganizationByNodeIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Organization` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the `Organization` being updated.
+  """
+  patch: OrganizationPatch!
+}
+
+"""All input for the `updateOrganization` mutation."""
+input UpdateOrganizationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Organization` being updated.
+  """
+  patch: OrganizationPatch!
+  id: Int!
+}
+
+"""The output of our update `Organization` mutation."""
+type UpdateOrganizationPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Organization` that was updated by this mutation."""
+  organization: Organization
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `Organization`. May be used by Relay 1."""
+  organizationEdge(
+    """The method to use when ordering `Organization`."""
+    orderBy: [OrganizationsOrderBy!] = PRIMARY_KEY_ASC
+  ): OrganizationsEdge
+}
+
+"""All input for the `updateTeamByNodeId` mutation."""
+input UpdateTeamByNodeIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Team` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the `Team` being updated.
+  """
+  patch: TeamPatch!
+}
+
+"""All input for the `updateTeam` mutation."""
+input UpdateTeamInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Team` being updated.
+  """
+  patch: TeamPatch!
+  id: Int!
+}
+
+"""The output of our update `Team` mutation."""
+type UpdateTeamPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Team` that was updated by this mutation."""
+  team: Team
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `Team`. May be used by Relay 1."""
+  teamEdge(
+    """The method to use when ordering `Team`."""
+    orderBy: [TeamsOrderBy!] = PRIMARY_KEY_ASC
+  ): TeamsEdge
+}
+
+"""All input for the `updateUserByNodeId` mutation."""
+input UpdateUserByNodeIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `User` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the `User` being updated.
+  """
+  patch: UserPatch!
+}
+
+"""All input for the `updateUser` mutation."""
+input UpdateUserInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `User` being updated.
+  """
+  patch: UserPatch!
+  id: Int!
+}
+
+"""The output of our update `User` mutation."""
+type UpdateUserPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `User` that was updated by this mutation."""
+  user: User
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `User`. May be used by Relay 1."""
+  userEdge(
+    """The method to use when ordering `User`."""
+    orderBy: [UsersOrderBy!] = PRIMARY_KEY_ASC
+  ): UsersEdge
+}
+
+type User implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  username: String
+
+  """Reads and enables pagination through a set of `GoalContributor`."""
+  goalContributorsByContributorId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `GoalContributor`."""
+    orderBy: [GoalContributorsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalContributorCondition
+  ): GoalContributorsConnection!
+
+  """Reads and enables pagination through a set of `GoalContributor`."""
+  goalContributorsByContributorIdList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `GoalContributor`."""
+    orderBy: [GoalContributorsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalContributorCondition
+  ): [GoalContributor!]!
+}
+
+"""
+A condition to be used against `User` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input UserCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `username` field."""
+  username: String
+}
+
+"""An input for mutations affecting `User`"""
+input UserInput {
+  id: Int
+  username: String
+}
+
+"""
+Represents an update to a `User`. Fields that are set will be updated.
+"""
+input UserPatch {
+  id: Int
+  username: String
+}
+
+"""A connection to a list of `User` values."""
+type UsersConnection {
+  """A list of `User` objects."""
+  nodes: [User]!
+
+  """
+  A list of edges which contains the `User` and cursor to aid in pagination.
+  """
+  edges: [UsersEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `User` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `User` edge in the connection."""
+type UsersEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `User` at the end of the edge."""
+  node: User
+}
+
+"""Methods to use when ordering `User`."""
+enum UsersOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  USERNAME_ASC
+  USERNAME_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
+"""
+scalar UUID

--- a/tests/multikey_refs/schema.sql
+++ b/tests/multikey_refs/schema.sql
@@ -1,0 +1,33 @@
+create table users (
+  id serial primary key,
+  username text
+);
+
+create table organizations (
+  id serial primary key,
+  name text
+);
+
+create table teams (
+  id serial primary key,
+  name text
+);
+
+create table goals (
+  organization_id int not null references organizations,
+  team_id int not null references teams,
+  goal_uuid uuid not null default gen_random_uuid(),
+  aim text,
+  primary key(organization_id, team_id, goal_uuid)
+);
+
+create table goal_contributors (
+  id serial primary key,
+  organization_id int not null references organizations,
+  team_id int not null references teams,
+  goal_uuid uuid not null,
+  contributor_id int not null references users,
+  contribution text,
+
+  foreign key (organization_id, team_id, goal_uuid) references goals
+);

--- a/tests/multikey_refs/schema.unsimplified.graphql
+++ b/tests/multikey_refs/schema.unsimplified.graphql
@@ -1,0 +1,1999 @@
+"""All input for the create `GoalContributor` mutation."""
+input CreateGoalContributorInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `GoalContributor` to be created by this mutation."""
+  goalContributor: GoalContributorInput!
+}
+
+"""The output of our create `GoalContributor` mutation."""
+type CreateGoalContributorPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `GoalContributor` that was created by this mutation."""
+  goalContributor: GoalContributor
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """
+  Reads a single `Organization` that is related to this `GoalContributor`.
+  """
+  organizationByOrganizationId: Organization
+
+  """Reads a single `Goal` that is related to this `GoalContributor`."""
+  goalByOrganizationIdAndTeamIdAndGoalUuid: Goal
+
+  """Reads a single `Team` that is related to this `GoalContributor`."""
+  teamByTeamId: Team
+
+  """Reads a single `User` that is related to this `GoalContributor`."""
+  userByContributorId: User
+
+  """An edge for our `GoalContributor`. May be used by Relay 1."""
+  goalContributorEdge(
+    """The method to use when ordering `GoalContributor`."""
+    orderBy: [GoalContributorsOrderBy!] = PRIMARY_KEY_ASC
+  ): GoalContributorsEdge
+}
+
+"""All input for the create `Goal` mutation."""
+input CreateGoalInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `Goal` to be created by this mutation."""
+  goal: GoalInput!
+}
+
+"""The output of our create `Goal` mutation."""
+type CreateGoalPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Goal` that was created by this mutation."""
+  goal: Goal
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single `Organization` that is related to this `Goal`."""
+  organizationByOrganizationId: Organization
+
+  """Reads a single `Team` that is related to this `Goal`."""
+  teamByTeamId: Team
+
+  """An edge for our `Goal`. May be used by Relay 1."""
+  goalEdge(
+    """The method to use when ordering `Goal`."""
+    orderBy: [GoalsOrderBy!] = PRIMARY_KEY_ASC
+  ): GoalsEdge
+}
+
+"""All input for the create `Organization` mutation."""
+input CreateOrganizationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `Organization` to be created by this mutation."""
+  organization: OrganizationInput!
+}
+
+"""The output of our create `Organization` mutation."""
+type CreateOrganizationPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Organization` that was created by this mutation."""
+  organization: Organization
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `Organization`. May be used by Relay 1."""
+  organizationEdge(
+    """The method to use when ordering `Organization`."""
+    orderBy: [OrganizationsOrderBy!] = PRIMARY_KEY_ASC
+  ): OrganizationsEdge
+}
+
+"""All input for the create `Team` mutation."""
+input CreateTeamInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `Team` to be created by this mutation."""
+  team: TeamInput!
+}
+
+"""The output of our create `Team` mutation."""
+type CreateTeamPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Team` that was created by this mutation."""
+  team: Team
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `Team`. May be used by Relay 1."""
+  teamEdge(
+    """The method to use when ordering `Team`."""
+    orderBy: [TeamsOrderBy!] = PRIMARY_KEY_ASC
+  ): TeamsEdge
+}
+
+"""All input for the create `User` mutation."""
+input CreateUserInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `User` to be created by this mutation."""
+  user: UserInput!
+}
+
+"""The output of our create `User` mutation."""
+type CreateUserPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `User` that was created by this mutation."""
+  user: User
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `User`. May be used by Relay 1."""
+  userEdge(
+    """The method to use when ordering `User`."""
+    orderBy: [UsersOrderBy!] = PRIMARY_KEY_ASC
+  ): UsersEdge
+}
+
+"""A location in a connection that can be used for resuming pagination."""
+scalar Cursor
+
+"""
+All input for the `deleteGoalByOrganizationIdAndTeamIdAndGoalUuid` mutation.
+"""
+input DeleteGoalByOrganizationIdAndTeamIdAndGoalUuidInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  organizationId: Int!
+  teamId: Int!
+  goalUuid: UUID!
+}
+
+"""All input for the `deleteGoalContributorById` mutation."""
+input DeleteGoalContributorByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the `deleteGoalContributor` mutation."""
+input DeleteGoalContributorInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `GoalContributor` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete `GoalContributor` mutation."""
+type DeleteGoalContributorPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `GoalContributor` that was deleted by this mutation."""
+  goalContributor: GoalContributor
+  deletedGoalContributorId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """
+  Reads a single `Organization` that is related to this `GoalContributor`.
+  """
+  organizationByOrganizationId: Organization
+
+  """Reads a single `Goal` that is related to this `GoalContributor`."""
+  goalByOrganizationIdAndTeamIdAndGoalUuid: Goal
+
+  """Reads a single `Team` that is related to this `GoalContributor`."""
+  teamByTeamId: Team
+
+  """Reads a single `User` that is related to this `GoalContributor`."""
+  userByContributorId: User
+
+  """An edge for our `GoalContributor`. May be used by Relay 1."""
+  goalContributorEdge(
+    """The method to use when ordering `GoalContributor`."""
+    orderBy: [GoalContributorsOrderBy!] = PRIMARY_KEY_ASC
+  ): GoalContributorsEdge
+}
+
+"""All input for the `deleteGoal` mutation."""
+input DeleteGoalInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Goal` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete `Goal` mutation."""
+type DeleteGoalPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Goal` that was deleted by this mutation."""
+  goal: Goal
+  deletedGoalId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single `Organization` that is related to this `Goal`."""
+  organizationByOrganizationId: Organization
+
+  """Reads a single `Team` that is related to this `Goal`."""
+  teamByTeamId: Team
+
+  """An edge for our `Goal`. May be used by Relay 1."""
+  goalEdge(
+    """The method to use when ordering `Goal`."""
+    orderBy: [GoalsOrderBy!] = PRIMARY_KEY_ASC
+  ): GoalsEdge
+}
+
+"""All input for the `deleteOrganizationById` mutation."""
+input DeleteOrganizationByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the `deleteOrganization` mutation."""
+input DeleteOrganizationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Organization` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete `Organization` mutation."""
+type DeleteOrganizationPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Organization` that was deleted by this mutation."""
+  organization: Organization
+  deletedOrganizationId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `Organization`. May be used by Relay 1."""
+  organizationEdge(
+    """The method to use when ordering `Organization`."""
+    orderBy: [OrganizationsOrderBy!] = PRIMARY_KEY_ASC
+  ): OrganizationsEdge
+}
+
+"""All input for the `deleteTeamById` mutation."""
+input DeleteTeamByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the `deleteTeam` mutation."""
+input DeleteTeamInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Team` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete `Team` mutation."""
+type DeleteTeamPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Team` that was deleted by this mutation."""
+  team: Team
+  deletedTeamId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `Team`. May be used by Relay 1."""
+  teamEdge(
+    """The method to use when ordering `Team`."""
+    orderBy: [TeamsOrderBy!] = PRIMARY_KEY_ASC
+  ): TeamsEdge
+}
+
+"""All input for the `deleteUserById` mutation."""
+input DeleteUserByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the `deleteUser` mutation."""
+input DeleteUserInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `User` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete `User` mutation."""
+type DeleteUserPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `User` that was deleted by this mutation."""
+  user: User
+  deletedUserId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `User`. May be used by Relay 1."""
+  userEdge(
+    """The method to use when ordering `User`."""
+    orderBy: [UsersOrderBy!] = PRIMARY_KEY_ASC
+  ): UsersEdge
+}
+
+type Goal implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  organizationId: Int!
+  teamId: Int!
+  goalUuid: UUID!
+  aim: String
+
+  """Reads a single `Organization` that is related to this `Goal`."""
+  organizationByOrganizationId: Organization
+
+  """Reads a single `Team` that is related to this `Goal`."""
+  teamByTeamId: Team
+
+  """Reads and enables pagination through a set of `GoalContributor`."""
+  goalContributorsByOrganizationIdAndTeamIdAndGoalUuid(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `GoalContributor`."""
+    orderBy: [GoalContributorsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalContributorCondition
+  ): GoalContributorsConnection!
+
+  """Reads and enables pagination through a set of `GoalContributor`."""
+  goalContributorsByOrganizationIdAndTeamIdAndGoalUuidList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `GoalContributor`."""
+    orderBy: [GoalContributorsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalContributorCondition
+  ): [GoalContributor!]!
+}
+
+"""
+A condition to be used against `Goal` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input GoalCondition {
+  """Checks for equality with the object’s `organizationId` field."""
+  organizationId: Int
+
+  """Checks for equality with the object’s `teamId` field."""
+  teamId: Int
+
+  """Checks for equality with the object’s `goalUuid` field."""
+  goalUuid: UUID
+
+  """Checks for equality with the object’s `aim` field."""
+  aim: String
+}
+
+type GoalContributor implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  organizationId: Int!
+  teamId: Int!
+  goalUuid: UUID!
+  contributorId: Int!
+  contribution: String
+
+  """
+  Reads a single `Organization` that is related to this `GoalContributor`.
+  """
+  organizationByOrganizationId: Organization
+
+  """Reads a single `Goal` that is related to this `GoalContributor`."""
+  goalByOrganizationIdAndTeamIdAndGoalUuid: Goal
+
+  """Reads a single `Team` that is related to this `GoalContributor`."""
+  teamByTeamId: Team
+
+  """Reads a single `User` that is related to this `GoalContributor`."""
+  userByContributorId: User
+}
+
+"""
+A condition to be used against `GoalContributor` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input GoalContributorCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `organizationId` field."""
+  organizationId: Int
+
+  """Checks for equality with the object’s `teamId` field."""
+  teamId: Int
+
+  """Checks for equality with the object’s `goalUuid` field."""
+  goalUuid: UUID
+
+  """Checks for equality with the object’s `contributorId` field."""
+  contributorId: Int
+
+  """Checks for equality with the object’s `contribution` field."""
+  contribution: String
+}
+
+"""An input for mutations affecting `GoalContributor`"""
+input GoalContributorInput {
+  id: Int
+  organizationId: Int!
+  teamId: Int!
+  goalUuid: UUID!
+  contributorId: Int!
+  contribution: String
+}
+
+"""
+Represents an update to a `GoalContributor`. Fields that are set will be updated.
+"""
+input GoalContributorPatch {
+  id: Int
+  organizationId: Int
+  teamId: Int
+  goalUuid: UUID
+  contributorId: Int
+  contribution: String
+}
+
+"""A connection to a list of `GoalContributor` values."""
+type GoalContributorsConnection {
+  """A list of `GoalContributor` objects."""
+  nodes: [GoalContributor]!
+
+  """
+  A list of edges which contains the `GoalContributor` and cursor to aid in pagination.
+  """
+  edges: [GoalContributorsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `GoalContributor` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+"""A `GoalContributor` edge in the connection."""
+type GoalContributorsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `GoalContributor` at the end of the edge."""
+  node: GoalContributor
+}
+
+"""Methods to use when ordering `GoalContributor`."""
+enum GoalContributorsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  ORGANIZATION_ID_ASC
+  ORGANIZATION_ID_DESC
+  TEAM_ID_ASC
+  TEAM_ID_DESC
+  GOAL_UUID_ASC
+  GOAL_UUID_DESC
+  CONTRIBUTOR_ID_ASC
+  CONTRIBUTOR_ID_DESC
+  CONTRIBUTION_ASC
+  CONTRIBUTION_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""An input for mutations affecting `Goal`"""
+input GoalInput {
+  organizationId: Int!
+  teamId: Int!
+  goalUuid: UUID
+  aim: String
+}
+
+"""
+Represents an update to a `Goal`. Fields that are set will be updated.
+"""
+input GoalPatch {
+  organizationId: Int
+  teamId: Int
+  goalUuid: UUID
+  aim: String
+}
+
+"""A connection to a list of `Goal` values."""
+type GoalsConnection {
+  """A list of `Goal` objects."""
+  nodes: [Goal]!
+
+  """
+  A list of edges which contains the `Goal` and cursor to aid in pagination.
+  """
+  edges: [GoalsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Goal` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Goal` edge in the connection."""
+type GoalsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Goal` at the end of the edge."""
+  node: Goal
+}
+
+"""Methods to use when ordering `Goal`."""
+enum GoalsOrderBy {
+  NATURAL
+  ORGANIZATION_ID_ASC
+  ORGANIZATION_ID_DESC
+  TEAM_ID_ASC
+  TEAM_ID_DESC
+  GOAL_UUID_ASC
+  GOAL_UUID_DESC
+  AIM_ASC
+  AIM_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+The root mutation type which contains root level fields which mutate data.
+"""
+type Mutation {
+  """Creates a single `GoalContributor`."""
+  createGoalContributor(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateGoalContributorInput!
+  ): CreateGoalContributorPayload
+
+  """Creates a single `Goal`."""
+  createGoal(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateGoalInput!
+  ): CreateGoalPayload
+
+  """Creates a single `Organization`."""
+  createOrganization(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateOrganizationInput!
+  ): CreateOrganizationPayload
+
+  """Creates a single `Team`."""
+  createTeam(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateTeamInput!
+  ): CreateTeamPayload
+
+  """Creates a single `User`."""
+  createUser(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateUserInput!
+  ): CreateUserPayload
+
+  """
+  Updates a single `GoalContributor` using its globally unique id and a patch.
+  """
+  updateGoalContributor(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateGoalContributorInput!
+  ): UpdateGoalContributorPayload
+
+  """Updates a single `GoalContributor` using a unique key and a patch."""
+  updateGoalContributorById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateGoalContributorByIdInput!
+  ): UpdateGoalContributorPayload
+
+  """Updates a single `Goal` using its globally unique id and a patch."""
+  updateGoal(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateGoalInput!
+  ): UpdateGoalPayload
+
+  """Updates a single `Goal` using a unique key and a patch."""
+  updateGoalByOrganizationIdAndTeamIdAndGoalUuid(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateGoalByOrganizationIdAndTeamIdAndGoalUuidInput!
+  ): UpdateGoalPayload
+
+  """
+  Updates a single `Organization` using its globally unique id and a patch.
+  """
+  updateOrganization(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateOrganizationInput!
+  ): UpdateOrganizationPayload
+
+  """Updates a single `Organization` using a unique key and a patch."""
+  updateOrganizationById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateOrganizationByIdInput!
+  ): UpdateOrganizationPayload
+
+  """Updates a single `Team` using its globally unique id and a patch."""
+  updateTeam(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateTeamInput!
+  ): UpdateTeamPayload
+
+  """Updates a single `Team` using a unique key and a patch."""
+  updateTeamById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateTeamByIdInput!
+  ): UpdateTeamPayload
+
+  """Updates a single `User` using its globally unique id and a patch."""
+  updateUser(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateUserInput!
+  ): UpdateUserPayload
+
+  """Updates a single `User` using a unique key and a patch."""
+  updateUserById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateUserByIdInput!
+  ): UpdateUserPayload
+
+  """Deletes a single `GoalContributor` using its globally unique id."""
+  deleteGoalContributor(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteGoalContributorInput!
+  ): DeleteGoalContributorPayload
+
+  """Deletes a single `GoalContributor` using a unique key."""
+  deleteGoalContributorById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteGoalContributorByIdInput!
+  ): DeleteGoalContributorPayload
+
+  """Deletes a single `Goal` using its globally unique id."""
+  deleteGoal(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteGoalInput!
+  ): DeleteGoalPayload
+
+  """Deletes a single `Goal` using a unique key."""
+  deleteGoalByOrganizationIdAndTeamIdAndGoalUuid(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteGoalByOrganizationIdAndTeamIdAndGoalUuidInput!
+  ): DeleteGoalPayload
+
+  """Deletes a single `Organization` using its globally unique id."""
+  deleteOrganization(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteOrganizationInput!
+  ): DeleteOrganizationPayload
+
+  """Deletes a single `Organization` using a unique key."""
+  deleteOrganizationById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteOrganizationByIdInput!
+  ): DeleteOrganizationPayload
+
+  """Deletes a single `Team` using its globally unique id."""
+  deleteTeam(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteTeamInput!
+  ): DeleteTeamPayload
+
+  """Deletes a single `Team` using a unique key."""
+  deleteTeamById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteTeamByIdInput!
+  ): DeleteTeamPayload
+
+  """Deletes a single `User` using its globally unique id."""
+  deleteUser(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteUserInput!
+  ): DeleteUserPayload
+
+  """Deletes a single `User` using a unique key."""
+  deleteUserById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteUserByIdInput!
+  ): DeleteUserPayload
+}
+
+"""An object with a globally unique `ID`."""
+interface Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+type Organization implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  name: String
+
+  """Reads and enables pagination through a set of `Goal`."""
+  goalsByOrganizationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Goal`."""
+    orderBy: [GoalsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalCondition
+  ): GoalsConnection!
+
+  """Reads and enables pagination through a set of `Goal`."""
+  goalsByOrganizationIdList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Goal`."""
+    orderBy: [GoalsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalCondition
+  ): [Goal!]!
+
+  """Reads and enables pagination through a set of `GoalContributor`."""
+  goalContributorsByOrganizationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `GoalContributor`."""
+    orderBy: [GoalContributorsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalContributorCondition
+  ): GoalContributorsConnection!
+
+  """Reads and enables pagination through a set of `GoalContributor`."""
+  goalContributorsByOrganizationIdList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `GoalContributor`."""
+    orderBy: [GoalContributorsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalContributorCondition
+  ): [GoalContributor!]!
+}
+
+"""
+A condition to be used against `Organization` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input OrganizationCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `name` field."""
+  name: String
+}
+
+"""An input for mutations affecting `Organization`"""
+input OrganizationInput {
+  id: Int
+  name: String
+}
+
+"""
+Represents an update to a `Organization`. Fields that are set will be updated.
+"""
+input OrganizationPatch {
+  id: Int
+  name: String
+}
+
+"""A connection to a list of `Organization` values."""
+type OrganizationsConnection {
+  """A list of `Organization` objects."""
+  nodes: [Organization]!
+
+  """
+  A list of edges which contains the `Organization` and cursor to aid in pagination.
+  """
+  edges: [OrganizationsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Organization` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Organization` edge in the connection."""
+type OrganizationsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Organization` at the end of the edge."""
+  node: Organization
+}
+
+"""Methods to use when ordering `Organization`."""
+enum OrganizationsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: Cursor
+
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+}
+
+"""The root query type which gives access points into the data universe."""
+type Query implements Node {
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
+
+  """
+  The root query type must be a `Node` to work well with Relay 1 mutations. This just resolves to `query`.
+  """
+  nodeId: ID!
+
+  """Fetches an object given its globally unique `ID`."""
+  node(
+    """The globally unique `ID`."""
+    nodeId: ID!
+  ): Node
+
+  """Reads and enables pagination through a set of `GoalContributor`."""
+  allGoalContributors(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `GoalContributor`."""
+    orderBy: [GoalContributorsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalContributorCondition
+  ): GoalContributorsConnection
+
+  """Reads a set of `GoalContributor`."""
+  allGoalContributorsList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `GoalContributor`."""
+    orderBy: [GoalContributorsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalContributorCondition
+  ): [GoalContributor!]
+
+  """Reads and enables pagination through a set of `Goal`."""
+  allGoals(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Goal`."""
+    orderBy: [GoalsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalCondition
+  ): GoalsConnection
+
+  """Reads a set of `Goal`."""
+  allGoalsList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Goal`."""
+    orderBy: [GoalsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalCondition
+  ): [Goal!]
+
+  """Reads and enables pagination through a set of `Organization`."""
+  allOrganizations(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Organization`."""
+    orderBy: [OrganizationsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: OrganizationCondition
+  ): OrganizationsConnection
+
+  """Reads a set of `Organization`."""
+  allOrganizationsList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Organization`."""
+    orderBy: [OrganizationsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: OrganizationCondition
+  ): [Organization!]
+
+  """Reads and enables pagination through a set of `Team`."""
+  allTeams(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Team`."""
+    orderBy: [TeamsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TeamCondition
+  ): TeamsConnection
+
+  """Reads a set of `Team`."""
+  allTeamsList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Team`."""
+    orderBy: [TeamsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TeamCondition
+  ): [Team!]
+
+  """Reads and enables pagination through a set of `User`."""
+  allUsers(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `User`."""
+    orderBy: [UsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: UserCondition
+  ): UsersConnection
+
+  """Reads a set of `User`."""
+  allUsersList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `User`."""
+    orderBy: [UsersOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: UserCondition
+  ): [User!]
+  goalContributorById(id: Int!): GoalContributor
+  goalByOrganizationIdAndTeamIdAndGoalUuid(organizationId: Int!, teamId: Int!, goalUuid: UUID!): Goal
+  organizationById(id: Int!): Organization
+  teamById(id: Int!): Team
+  userById(id: Int!): User
+
+  """Reads a single `GoalContributor` using its globally unique `ID`."""
+  goalContributor(
+    """
+    The globally unique `ID` to be used in selecting a single `GoalContributor`.
+    """
+    nodeId: ID!
+  ): GoalContributor
+
+  """Reads a single `Goal` using its globally unique `ID`."""
+  goal(
+    """The globally unique `ID` to be used in selecting a single `Goal`."""
+    nodeId: ID!
+  ): Goal
+
+  """Reads a single `Organization` using its globally unique `ID`."""
+  organization(
+    """
+    The globally unique `ID` to be used in selecting a single `Organization`.
+    """
+    nodeId: ID!
+  ): Organization
+
+  """Reads a single `Team` using its globally unique `ID`."""
+  team(
+    """The globally unique `ID` to be used in selecting a single `Team`."""
+    nodeId: ID!
+  ): Team
+
+  """Reads a single `User` using its globally unique `ID`."""
+  user(
+    """The globally unique `ID` to be used in selecting a single `User`."""
+    nodeId: ID!
+  ): User
+}
+
+type Team implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  name: String
+
+  """Reads and enables pagination through a set of `Goal`."""
+  goalsByTeamId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Goal`."""
+    orderBy: [GoalsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalCondition
+  ): GoalsConnection!
+
+  """Reads and enables pagination through a set of `Goal`."""
+  goalsByTeamIdList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Goal`."""
+    orderBy: [GoalsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalCondition
+  ): [Goal!]!
+
+  """Reads and enables pagination through a set of `GoalContributor`."""
+  goalContributorsByTeamId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `GoalContributor`."""
+    orderBy: [GoalContributorsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalContributorCondition
+  ): GoalContributorsConnection!
+
+  """Reads and enables pagination through a set of `GoalContributor`."""
+  goalContributorsByTeamIdList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `GoalContributor`."""
+    orderBy: [GoalContributorsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalContributorCondition
+  ): [GoalContributor!]!
+}
+
+"""
+A condition to be used against `Team` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input TeamCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `name` field."""
+  name: String
+}
+
+"""An input for mutations affecting `Team`"""
+input TeamInput {
+  id: Int
+  name: String
+}
+
+"""
+Represents an update to a `Team`. Fields that are set will be updated.
+"""
+input TeamPatch {
+  id: Int
+  name: String
+}
+
+"""A connection to a list of `Team` values."""
+type TeamsConnection {
+  """A list of `Team` objects."""
+  nodes: [Team]!
+
+  """
+  A list of edges which contains the `Team` and cursor to aid in pagination.
+  """
+  edges: [TeamsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Team` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Team` edge in the connection."""
+type TeamsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Team` at the end of the edge."""
+  node: Team
+}
+
+"""Methods to use when ordering `Team`."""
+enum TeamsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+All input for the `updateGoalByOrganizationIdAndTeamIdAndGoalUuid` mutation.
+"""
+input UpdateGoalByOrganizationIdAndTeamIdAndGoalUuidInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Goal` being updated.
+  """
+  goalPatch: GoalPatch!
+  organizationId: Int!
+  teamId: Int!
+  goalUuid: UUID!
+}
+
+"""All input for the `updateGoalContributorById` mutation."""
+input UpdateGoalContributorByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `GoalContributor` being updated.
+  """
+  goalContributorPatch: GoalContributorPatch!
+  id: Int!
+}
+
+"""All input for the `updateGoalContributor` mutation."""
+input UpdateGoalContributorInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `GoalContributor` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the `GoalContributor` being updated.
+  """
+  goalContributorPatch: GoalContributorPatch!
+}
+
+"""The output of our update `GoalContributor` mutation."""
+type UpdateGoalContributorPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `GoalContributor` that was updated by this mutation."""
+  goalContributor: GoalContributor
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """
+  Reads a single `Organization` that is related to this `GoalContributor`.
+  """
+  organizationByOrganizationId: Organization
+
+  """Reads a single `Goal` that is related to this `GoalContributor`."""
+  goalByOrganizationIdAndTeamIdAndGoalUuid: Goal
+
+  """Reads a single `Team` that is related to this `GoalContributor`."""
+  teamByTeamId: Team
+
+  """Reads a single `User` that is related to this `GoalContributor`."""
+  userByContributorId: User
+
+  """An edge for our `GoalContributor`. May be used by Relay 1."""
+  goalContributorEdge(
+    """The method to use when ordering `GoalContributor`."""
+    orderBy: [GoalContributorsOrderBy!] = PRIMARY_KEY_ASC
+  ): GoalContributorsEdge
+}
+
+"""All input for the `updateGoal` mutation."""
+input UpdateGoalInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Goal` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the `Goal` being updated.
+  """
+  goalPatch: GoalPatch!
+}
+
+"""The output of our update `Goal` mutation."""
+type UpdateGoalPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Goal` that was updated by this mutation."""
+  goal: Goal
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single `Organization` that is related to this `Goal`."""
+  organizationByOrganizationId: Organization
+
+  """Reads a single `Team` that is related to this `Goal`."""
+  teamByTeamId: Team
+
+  """An edge for our `Goal`. May be used by Relay 1."""
+  goalEdge(
+    """The method to use when ordering `Goal`."""
+    orderBy: [GoalsOrderBy!] = PRIMARY_KEY_ASC
+  ): GoalsEdge
+}
+
+"""All input for the `updateOrganizationById` mutation."""
+input UpdateOrganizationByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Organization` being updated.
+  """
+  organizationPatch: OrganizationPatch!
+  id: Int!
+}
+
+"""All input for the `updateOrganization` mutation."""
+input UpdateOrganizationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Organization` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the `Organization` being updated.
+  """
+  organizationPatch: OrganizationPatch!
+}
+
+"""The output of our update `Organization` mutation."""
+type UpdateOrganizationPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Organization` that was updated by this mutation."""
+  organization: Organization
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `Organization`. May be used by Relay 1."""
+  organizationEdge(
+    """The method to use when ordering `Organization`."""
+    orderBy: [OrganizationsOrderBy!] = PRIMARY_KEY_ASC
+  ): OrganizationsEdge
+}
+
+"""All input for the `updateTeamById` mutation."""
+input UpdateTeamByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Team` being updated.
+  """
+  teamPatch: TeamPatch!
+  id: Int!
+}
+
+"""All input for the `updateTeam` mutation."""
+input UpdateTeamInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Team` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the `Team` being updated.
+  """
+  teamPatch: TeamPatch!
+}
+
+"""The output of our update `Team` mutation."""
+type UpdateTeamPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Team` that was updated by this mutation."""
+  team: Team
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `Team`. May be used by Relay 1."""
+  teamEdge(
+    """The method to use when ordering `Team`."""
+    orderBy: [TeamsOrderBy!] = PRIMARY_KEY_ASC
+  ): TeamsEdge
+}
+
+"""All input for the `updateUserById` mutation."""
+input UpdateUserByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `User` being updated.
+  """
+  userPatch: UserPatch!
+  id: Int!
+}
+
+"""All input for the `updateUser` mutation."""
+input UpdateUserInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `User` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the `User` being updated.
+  """
+  userPatch: UserPatch!
+}
+
+"""The output of our update `User` mutation."""
+type UpdateUserPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `User` that was updated by this mutation."""
+  user: User
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `User`. May be used by Relay 1."""
+  userEdge(
+    """The method to use when ordering `User`."""
+    orderBy: [UsersOrderBy!] = PRIMARY_KEY_ASC
+  ): UsersEdge
+}
+
+type User implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  username: String
+
+  """Reads and enables pagination through a set of `GoalContributor`."""
+  goalContributorsByContributorId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `GoalContributor`."""
+    orderBy: [GoalContributorsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalContributorCondition
+  ): GoalContributorsConnection!
+
+  """Reads and enables pagination through a set of `GoalContributor`."""
+  goalContributorsByContributorIdList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `GoalContributor`."""
+    orderBy: [GoalContributorsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GoalContributorCondition
+  ): [GoalContributor!]!
+}
+
+"""
+A condition to be used against `User` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input UserCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `username` field."""
+  username: String
+}
+
+"""An input for mutations affecting `User`"""
+input UserInput {
+  id: Int
+  username: String
+}
+
+"""
+Represents an update to a `User`. Fields that are set will be updated.
+"""
+input UserPatch {
+  id: Int
+  username: String
+}
+
+"""A connection to a list of `User` values."""
+type UsersConnection {
+  """A list of `User` objects."""
+  nodes: [User]!
+
+  """
+  A list of edges which contains the `User` and cursor to aid in pagination.
+  """
+  edges: [UsersEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `User` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `User` edge in the connection."""
+type UsersEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `User` at the end of the edge."""
+  node: User
+}
+
+"""Methods to use when ordering `User`."""
+enum UsersOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  USERNAME_ASC
+  USERNAME_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
+"""
+scalar UUID


### PR DESCRIPTION
`foreign key (organization_id, team_id, goal_id) references goals` was previously `goalByOrganizationIdAndTeamIdAndGoalId`. This PR changes it to `organizationTeamGoal`.