### PR TITLE
feat: `@listSuffix omit/include` smart tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ stick to it.
 It's unlikely we'll have much in the way of minor releases since all naming
 changes are breaking.
 
+# v6.1.0
+
+### Add `@listSuffix` smart tag
+
+Previously there was no easy way to override `pgOmitListSuffix` on a per-entity
+basis. With the `@listSuffix` tag you can selectively control naming of both
+collection types:
+
+```sql
+create table companies (id serial primary key);
+comment on table companies is E'@listSuffix omit';
+```
+
+By default (`pgOmitListSuffix = null` and `simpleCollections = 'both'`) this
+produces:
+
+```diff
+-  allCompanies(
++  companiesConnection(
+```
+
+```diff
+-  allCompaniesList(
++  companies(
+```
+
 # v6.0.0
 
 #### Pluralization fixes

--- a/README.md
+++ b/README.md
@@ -176,7 +176,9 @@ or a custom inflector to override these.
 In most cases, the conflict errors will guide you on how to fix these issues
 using [smart comments](https://www.graphile.org/postgraphile/smart-comments/).
 
-## New smart tags
+## Smart Tags
+
+### `@foreignSimpleFieldName`
 
 `@foreignSimpleFieldName` was added to override the naming of the foreign-side
 of a one-to-many relationship's simple collections field (if you're using simple
@@ -185,3 +187,26 @@ suffix" ("List" by default, but "" if `pgOmitListSuffix` is set), but if you
 prefer you can override it entirely with `@foreignSimpleFieldName`. If you set
 `@foreignSimpleFieldName` and you're using `simpleCollections 'both'` then you
 should also set `@foreignFieldName` explicitly or unexpected things may occur.
+
+Applies to:
+
+- foreign key constraints
+
+### `@listSuffix`
+
+`@listSuffix` allows you to override the default naming on a per-entity basis,
+overriding `pgOmitListSuffix`. For example, with `pgOmitListSuffix: true`, you
+can apply `@listSuffix include` to have the list suffix appended to the simple
+collection generated for that table. When `pgOmitListSuffix` is not `true`, then
+you can use `@listSuffix omit` to selectively omit the list suffix on entities.
+
+If `@listSuffix` is set, the only valid values are `"omit"` and `"include"`. Any
+other value will cause an error.
+
+> NOTE: `@listSuffix` will have no effect when using `@foreignSimpleFieldName`.
+
+Applies to:
+
+- tables
+- foreign key constraints
+- computed column functions returning `SETOF <record type>`

--- a/README.md
+++ b/README.md
@@ -196,12 +196,19 @@ Applies to:
 
 `@listSuffix` allows you to override the default naming on a per-entity basis,
 overriding `pgOmitListSuffix`. For example, with `pgOmitListSuffix: true`, you
-can apply `@listSuffix include` to have the list suffix appended to the simple
-collection generated for that table. When `pgOmitListSuffix` is not `true`, then
-you can use `@listSuffix omit` to selectively omit the list suffix on entities.
+can apply `@listSuffix include` to have the `-List` suffix appended to the simple
+collection generated for that table, and remove the `-Connection` suffix from the
+Relay connection. When `pgOmitListSuffix` is not `true`, you can use
+`@listSuffix omit` to selectively omit the `-List` suffix on simple collections
+and append `-Connection` to the Relay connection instead.
 
 If `@listSuffix` is set, the only valid values are `"omit"` and `"include"`. Any
 other value will cause an error.
+
+|                   | @listSuffix omit    | @listSuffix include |
+| ----------------: | :------------------ | :------------------ |
+|  Relay Connection | companiesConnection | companies           |
+| Simple Collection | companies           | companiesList       |
 
 > NOTE: `@listSuffix` will have no effect when using `@foreignSimpleFieldName`.
 

--- a/tests/list_suffix_omit/schema.graphql.diff
+++ b/tests/list_suffix_omit/schema.graphql.diff
@@ -1,0 +1,132 @@
+--- unsimplified
++++ simplified
+@@ -9,10 +9,10 @@
+   name: String!
+ 
+   """Reads a single `Company` that is related to this `Beverage`."""
+-  companyByCompanyId: Company
++  company: Company
+ 
+   """Reads a single `Company` that is related to this `Beverage`."""
+-  companyByDistributorId: Company
++  distributor: Company
+ }
+ 
+ """
+@@ -120,7 +120,7 @@
+   name: String!
+ 
+   """Reads and enables pagination through a set of `Beverage`."""
+-  beveragesByCompanyId(
++  beveragesConnection(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -149,7 +149,7 @@
+   ): BeveragesConnection!
+ 
+   """Reads and enables pagination through a set of `Beverage`."""
+-  beveragesByCompanyIdList(
++  beverages(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -242,7 +242,7 @@
+   ): [Beverage]
+ 
+   """Reads and enables pagination through a set of `Beverage`."""
+-  computedListOmit(
++  computedListOmitConnection(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -263,7 +263,7 @@
+   ): BeveragesConnection!
+ 
+   """Reads and enables pagination through a set of `Beverage`."""
+-  computedListOmitList(
++  computedListOmit(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -329,7 +329,7 @@
+   ): Node
+ 
+   """Reads and enables pagination through a set of `Beverage`."""
+-  allBeverages(
++  beverages(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -358,7 +358,7 @@
+   ): BeveragesConnection
+ 
+   """Reads a set of `Beverage`."""
+-  allBeveragesList(
++  beveragesList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -375,7 +375,7 @@
+   ): [Beverage!]
+ 
+   """Reads and enables pagination through a set of `Company`."""
+-  allCompanies(
++  companiesConnection(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -404,7 +404,7 @@
+   ): CompaniesConnection
+ 
+   """Reads a set of `Company`."""
+-  allCompaniesList(
++  companies(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -419,8 +419,8 @@
+     """
+     condition: CompanyCondition
+   ): [Company!]
+-  beverageById(id: Int!): Beverage
+-  companyById(id: Int!): Company
++  beverage(id: Int!): Beverage
++  company(id: Int!): Company
+ 
+   """Reads and enables pagination through a set of `Beverage`."""
+   listInclude(
+@@ -453,7 +453,7 @@
+   ): [Beverage]
+ 
+   """Reads and enables pagination through a set of `Beverage`."""
+-  listOmit(
++  listOmitConnection(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -474,7 +474,7 @@
+   ): BeveragesConnection
+ 
+   """Reads and enables pagination through a set of `Beverage`."""
+-  listOmitList(
++  listOmit(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -483,13 +483,13 @@
+   ): [Beverage]
+ 
+   """Reads a single `Beverage` using its globally unique `ID`."""
+-  beverage(
++  beverageByNodeId(
+     """The globally unique `ID` to be used in selecting a single `Beverage`."""
+     nodeId: ID!
+   ): Beverage
+ 
+   """Reads a single `Company` using its globally unique `ID`."""
+-  company(
++  companyByNodeId(
+     """The globally unique `ID` to be used in selecting a single `Company`."""
+     nodeId: ID!
+   ): Company

--- a/tests/list_suffix_omit/schema.simplified.graphql
+++ b/tests/list_suffix_omit/schema.simplified.graphql
@@ -1,0 +1,496 @@
+type Beverage implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  companyId: Int!
+  distributorId: Int
+  name: String!
+
+  """Reads a single `Company` that is related to this `Beverage`."""
+  company: Company
+
+  """Reads a single `Company` that is related to this `Beverage`."""
+  distributor: Company
+}
+
+"""
+A condition to be used against `Beverage` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input BeverageCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `companyId` field."""
+  companyId: Int
+
+  """Checks for equality with the object’s `distributorId` field."""
+  distributorId: Int
+
+  """Checks for equality with the object’s `name` field."""
+  name: String
+}
+
+"""A connection to a list of `Beverage` values."""
+type BeveragesConnection {
+  """A list of `Beverage` objects."""
+  nodes: [Beverage]!
+
+  """
+  A list of edges which contains the `Beverage` and cursor to aid in pagination.
+  """
+  edges: [BeveragesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Beverage` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Beverage` edge in the connection."""
+type BeveragesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Beverage` at the end of the edge."""
+  node: Beverage
+}
+
+"""Methods to use when ordering `Beverage`."""
+enum BeveragesOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  COMPANY_ID_ASC
+  COMPANY_ID_DESC
+  DISTRIBUTOR_ID_ASC
+  DISTRIBUTOR_ID_DESC
+  NAME_ASC
+  NAME_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""A connection to a list of `Company` values."""
+type CompaniesConnection {
+  """A list of `Company` objects."""
+  nodes: [Company]!
+
+  """
+  A list of edges which contains the `Company` and cursor to aid in pagination.
+  """
+  edges: [CompaniesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Company` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Company` edge in the connection."""
+type CompaniesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Company` at the end of the edge."""
+  node: Company
+}
+
+"""Methods to use when ordering `Company`."""
+enum CompaniesOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+type Company implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  name: String!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  beveragesConnection(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Beverage`."""
+    orderBy: [BeveragesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BeverageCondition
+  ): BeveragesConnection!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  beverages(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Beverage`."""
+    orderBy: [BeveragesOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BeverageCondition
+  ): [Beverage!]!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  distributedBeverages(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Beverage`."""
+    orderBy: [BeveragesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BeverageCondition
+  ): BeveragesConnection!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  distributedBeveragesListing(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Beverage`."""
+    orderBy: [BeveragesOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BeverageCondition
+  ): [Beverage!]!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  computedListInclude(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+  ): BeveragesConnection!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  computedListIncludeList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Beverage]
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  computedListOmitConnection(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+  ): BeveragesConnection!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  computedListOmit(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Beverage]
+}
+
+"""
+A condition to be used against `Company` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input CompanyCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `name` field."""
+  name: String
+}
+
+"""A location in a connection that can be used for resuming pagination."""
+scalar Cursor
+
+"""An object with a globally unique `ID`."""
+interface Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: Cursor
+
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+}
+
+"""The root query type which gives access points into the data universe."""
+type Query implements Node {
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
+
+  """
+  The root query type must be a `Node` to work well with Relay 1 mutations. This just resolves to `query`.
+  """
+  nodeId: ID!
+
+  """Fetches an object given its globally unique `ID`."""
+  node(
+    """The globally unique `ID`."""
+    nodeId: ID!
+  ): Node
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  beverages(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Beverage`."""
+    orderBy: [BeveragesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BeverageCondition
+  ): BeveragesConnection
+
+  """Reads a set of `Beverage`."""
+  beveragesList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Beverage`."""
+    orderBy: [BeveragesOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BeverageCondition
+  ): [Beverage!]
+
+  """Reads and enables pagination through a set of `Company`."""
+  companiesConnection(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Company`."""
+    orderBy: [CompaniesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CompanyCondition
+  ): CompaniesConnection
+
+  """Reads a set of `Company`."""
+  companies(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Company`."""
+    orderBy: [CompaniesOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CompanyCondition
+  ): [Company!]
+  beverage(id: Int!): Beverage
+  company(id: Int!): Company
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  listInclude(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+  ): BeveragesConnection
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  listIncludeList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Beverage]
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  listOmitConnection(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+  ): BeveragesConnection
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  listOmit(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Beverage]
+
+  """Reads a single `Beverage` using its globally unique `ID`."""
+  beverageByNodeId(
+    """The globally unique `ID` to be used in selecting a single `Beverage`."""
+    nodeId: ID!
+  ): Beverage
+
+  """Reads a single `Company` using its globally unique `ID`."""
+  companyByNodeId(
+    """The globally unique `ID` to be used in selecting a single `Company`."""
+    nodeId: ID!
+  ): Company
+}

--- a/tests/list_suffix_omit/schema.sql
+++ b/tests/list_suffix_omit/schema.sql
@@ -1,0 +1,34 @@
+create table companies (
+  id serial primary key,
+  name text not null
+);
+comment on table companies is E'@listSuffix omit';
+
+create table beverages (
+  id serial primary key,
+  company_id int not null references companies,
+  distributor_id int references companies,
+  name text not null
+);
+comment on constraint "beverages_company_id_fkey" on "beverages" is E'@listSuffix omit';
+-- @omitListSuffix has no effect when @foreignSimpleFieldName is set
+comment on constraint "beverages_distributor_id_fkey" on "beverages" is
+  E'@foreignFieldName distributedBeverages\n@foreignSimpleFieldName distributedBeveragesListing\n@listSuffix omit';
+
+create function list_omit() returns setof beverages as $$
+  select * from beverages;
+$$ language sql stable;
+comment on function list_omit() is E'@listSuffix omit';
+
+create function list_include() returns setof beverages as $$
+  select * from beverages;
+$$ language sql stable;
+
+create function companies_computed_list_omit(company companies) returns setof beverages as $$
+  select * from beverages;
+$$ language sql stable;
+comment on function companies_computed_list_omit(companies) is E'@listSuffix omit';
+
+create function companies_computed_list_include(company companies) returns setof beverages as $$
+  select * from beverages;
+$$ language sql stable;

--- a/tests/list_suffix_omit/schema.unsimplified.graphql
+++ b/tests/list_suffix_omit/schema.unsimplified.graphql
@@ -1,0 +1,496 @@
+type Beverage implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  companyId: Int!
+  distributorId: Int
+  name: String!
+
+  """Reads a single `Company` that is related to this `Beverage`."""
+  companyByCompanyId: Company
+
+  """Reads a single `Company` that is related to this `Beverage`."""
+  companyByDistributorId: Company
+}
+
+"""
+A condition to be used against `Beverage` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input BeverageCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `companyId` field."""
+  companyId: Int
+
+  """Checks for equality with the object’s `distributorId` field."""
+  distributorId: Int
+
+  """Checks for equality with the object’s `name` field."""
+  name: String
+}
+
+"""A connection to a list of `Beverage` values."""
+type BeveragesConnection {
+  """A list of `Beverage` objects."""
+  nodes: [Beverage]!
+
+  """
+  A list of edges which contains the `Beverage` and cursor to aid in pagination.
+  """
+  edges: [BeveragesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Beverage` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Beverage` edge in the connection."""
+type BeveragesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Beverage` at the end of the edge."""
+  node: Beverage
+}
+
+"""Methods to use when ordering `Beverage`."""
+enum BeveragesOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  COMPANY_ID_ASC
+  COMPANY_ID_DESC
+  DISTRIBUTOR_ID_ASC
+  DISTRIBUTOR_ID_DESC
+  NAME_ASC
+  NAME_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""A connection to a list of `Company` values."""
+type CompaniesConnection {
+  """A list of `Company` objects."""
+  nodes: [Company]!
+
+  """
+  A list of edges which contains the `Company` and cursor to aid in pagination.
+  """
+  edges: [CompaniesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Company` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Company` edge in the connection."""
+type CompaniesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Company` at the end of the edge."""
+  node: Company
+}
+
+"""Methods to use when ordering `Company`."""
+enum CompaniesOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+type Company implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  name: String!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  beveragesByCompanyId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Beverage`."""
+    orderBy: [BeveragesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BeverageCondition
+  ): BeveragesConnection!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  beveragesByCompanyIdList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Beverage`."""
+    orderBy: [BeveragesOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BeverageCondition
+  ): [Beverage!]!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  distributedBeverages(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Beverage`."""
+    orderBy: [BeveragesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BeverageCondition
+  ): BeveragesConnection!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  distributedBeveragesListing(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Beverage`."""
+    orderBy: [BeveragesOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BeverageCondition
+  ): [Beverage!]!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  computedListInclude(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+  ): BeveragesConnection!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  computedListIncludeList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Beverage]
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  computedListOmit(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+  ): BeveragesConnection!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  computedListOmitList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Beverage]
+}
+
+"""
+A condition to be used against `Company` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input CompanyCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `name` field."""
+  name: String
+}
+
+"""A location in a connection that can be used for resuming pagination."""
+scalar Cursor
+
+"""An object with a globally unique `ID`."""
+interface Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: Cursor
+
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+}
+
+"""The root query type which gives access points into the data universe."""
+type Query implements Node {
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
+
+  """
+  The root query type must be a `Node` to work well with Relay 1 mutations. This just resolves to `query`.
+  """
+  nodeId: ID!
+
+  """Fetches an object given its globally unique `ID`."""
+  node(
+    """The globally unique `ID`."""
+    nodeId: ID!
+  ): Node
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  allBeverages(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Beverage`."""
+    orderBy: [BeveragesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BeverageCondition
+  ): BeveragesConnection
+
+  """Reads a set of `Beverage`."""
+  allBeveragesList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Beverage`."""
+    orderBy: [BeveragesOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BeverageCondition
+  ): [Beverage!]
+
+  """Reads and enables pagination through a set of `Company`."""
+  allCompanies(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Company`."""
+    orderBy: [CompaniesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CompanyCondition
+  ): CompaniesConnection
+
+  """Reads a set of `Company`."""
+  allCompaniesList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Company`."""
+    orderBy: [CompaniesOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CompanyCondition
+  ): [Company!]
+  beverageById(id: Int!): Beverage
+  companyById(id: Int!): Company
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  listInclude(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+  ): BeveragesConnection
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  listIncludeList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Beverage]
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  listOmit(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+  ): BeveragesConnection
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  listOmitList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Beverage]
+
+  """Reads a single `Beverage` using its globally unique `ID`."""
+  beverage(
+    """The globally unique `ID` to be used in selecting a single `Beverage`."""
+    nodeId: ID!
+  ): Beverage
+
+  """Reads a single `Company` using its globally unique `ID`."""
+  company(
+    """The globally unique `ID` to be used in selecting a single `Company`."""
+    nodeId: ID!
+  ): Company
+}

--- a/tests/list_suffix_omit/settings.json
+++ b/tests/list_suffix_omit/settings.json
@@ -1,0 +1,3 @@
+{
+  "disableDefaultMutations": true
+}

--- a/tests/pg_omit_list_suffix/schema.graphql.diff
+++ b/tests/pg_omit_list_suffix/schema.graphql.diff
@@ -1,0 +1,132 @@
+--- unsimplified
++++ simplified
+@@ -9,10 +9,10 @@
+   name: String!
+ 
+   """Reads a single `Company` that is related to this `Beverage`."""
+-  companyByCompanyId: Company
++  company: Company
+ 
+   """Reads a single `Company` that is related to this `Beverage`."""
+-  companyByDistributorId: Company
++  distributor: Company
+ }
+ 
+ """
+@@ -120,7 +120,7 @@
+   name: String!
+ 
+   """Reads and enables pagination through a set of `Beverage`."""
+-  beveragesByCompanyId(
++  beverages(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -149,7 +149,7 @@
+   ): BeveragesConnection!
+ 
+   """Reads and enables pagination through a set of `Beverage`."""
+-  beveragesByCompanyIdList(
++  beveragesList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -242,7 +242,7 @@
+   ): [Beverage]
+ 
+   """Reads and enables pagination through a set of `Beverage`."""
+-  computedListOmit(
++  computedListOmitConnection(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -263,7 +263,7 @@
+   ): BeveragesConnection!
+ 
+   """Reads and enables pagination through a set of `Beverage`."""
+-  computedListOmitList(
++  computedListOmit(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -329,7 +329,7 @@
+   ): Node
+ 
+   """Reads and enables pagination through a set of `Beverage`."""
+-  allBeverages(
++  beveragesConnection(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -358,7 +358,7 @@
+   ): BeveragesConnection
+ 
+   """Reads a set of `Beverage`."""
+-  allBeveragesList(
++  beverages(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -375,7 +375,7 @@
+   ): [Beverage!]
+ 
+   """Reads and enables pagination through a set of `Company`."""
+-  allCompanies(
++  companies(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -404,7 +404,7 @@
+   ): CompaniesConnection
+ 
+   """Reads a set of `Company`."""
+-  allCompaniesList(
++  companiesList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -419,8 +419,8 @@
+     """
+     condition: CompanyCondition
+   ): [Company!]
+-  beverageById(id: Int!): Beverage
+-  companyById(id: Int!): Company
++  beverage(id: Int!): Beverage
++  company(id: Int!): Company
+ 
+   """Reads and enables pagination through a set of `Beverage`."""
+   listInclude(
+@@ -453,7 +453,7 @@
+   ): [Beverage]
+ 
+   """Reads and enables pagination through a set of `Beverage`."""
+-  listOmit(
++  listOmitConnection(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -474,7 +474,7 @@
+   ): BeveragesConnection
+ 
+   """Reads and enables pagination through a set of `Beverage`."""
+-  listOmitList(
++  listOmit(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -483,13 +483,13 @@
+   ): [Beverage]
+ 
+   """Reads a single `Beverage` using its globally unique `ID`."""
+-  beverage(
++  beverageByNodeId(
+     """The globally unique `ID` to be used in selecting a single `Beverage`."""
+     nodeId: ID!
+   ): Beverage
+ 
+   """Reads a single `Company` using its globally unique `ID`."""
+-  company(
++  companyByNodeId(
+     """The globally unique `ID` to be used in selecting a single `Company`."""
+     nodeId: ID!
+   ): Company

--- a/tests/pg_omit_list_suffix/schema.simplified.graphql
+++ b/tests/pg_omit_list_suffix/schema.simplified.graphql
@@ -1,0 +1,496 @@
+type Beverage implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  companyId: Int!
+  distributorId: Int
+  name: String!
+
+  """Reads a single `Company` that is related to this `Beverage`."""
+  company: Company
+
+  """Reads a single `Company` that is related to this `Beverage`."""
+  distributor: Company
+}
+
+"""
+A condition to be used against `Beverage` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input BeverageCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `companyId` field."""
+  companyId: Int
+
+  """Checks for equality with the object’s `distributorId` field."""
+  distributorId: Int
+
+  """Checks for equality with the object’s `name` field."""
+  name: String
+}
+
+"""A connection to a list of `Beverage` values."""
+type BeveragesConnection {
+  """A list of `Beverage` objects."""
+  nodes: [Beverage]!
+
+  """
+  A list of edges which contains the `Beverage` and cursor to aid in pagination.
+  """
+  edges: [BeveragesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Beverage` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Beverage` edge in the connection."""
+type BeveragesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Beverage` at the end of the edge."""
+  node: Beverage
+}
+
+"""Methods to use when ordering `Beverage`."""
+enum BeveragesOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  COMPANY_ID_ASC
+  COMPANY_ID_DESC
+  DISTRIBUTOR_ID_ASC
+  DISTRIBUTOR_ID_DESC
+  NAME_ASC
+  NAME_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""A connection to a list of `Company` values."""
+type CompaniesConnection {
+  """A list of `Company` objects."""
+  nodes: [Company]!
+
+  """
+  A list of edges which contains the `Company` and cursor to aid in pagination.
+  """
+  edges: [CompaniesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Company` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Company` edge in the connection."""
+type CompaniesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Company` at the end of the edge."""
+  node: Company
+}
+
+"""Methods to use when ordering `Company`."""
+enum CompaniesOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+type Company implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  name: String!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  beverages(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Beverage`."""
+    orderBy: [BeveragesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BeverageCondition
+  ): BeveragesConnection!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  beveragesList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Beverage`."""
+    orderBy: [BeveragesOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BeverageCondition
+  ): [Beverage!]!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  distributedBeverages(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Beverage`."""
+    orderBy: [BeveragesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BeverageCondition
+  ): BeveragesConnection!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  distributedBeveragesListing(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Beverage`."""
+    orderBy: [BeveragesOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BeverageCondition
+  ): [Beverage!]!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  computedListInclude(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+  ): BeveragesConnection!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  computedListIncludeList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Beverage]
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  computedListOmitConnection(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+  ): BeveragesConnection!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  computedListOmit(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Beverage]
+}
+
+"""
+A condition to be used against `Company` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input CompanyCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `name` field."""
+  name: String
+}
+
+"""A location in a connection that can be used for resuming pagination."""
+scalar Cursor
+
+"""An object with a globally unique `ID`."""
+interface Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: Cursor
+
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+}
+
+"""The root query type which gives access points into the data universe."""
+type Query implements Node {
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
+
+  """
+  The root query type must be a `Node` to work well with Relay 1 mutations. This just resolves to `query`.
+  """
+  nodeId: ID!
+
+  """Fetches an object given its globally unique `ID`."""
+  node(
+    """The globally unique `ID`."""
+    nodeId: ID!
+  ): Node
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  beveragesConnection(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Beverage`."""
+    orderBy: [BeveragesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BeverageCondition
+  ): BeveragesConnection
+
+  """Reads a set of `Beverage`."""
+  beverages(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Beverage`."""
+    orderBy: [BeveragesOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BeverageCondition
+  ): [Beverage!]
+
+  """Reads and enables pagination through a set of `Company`."""
+  companies(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Company`."""
+    orderBy: [CompaniesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CompanyCondition
+  ): CompaniesConnection
+
+  """Reads a set of `Company`."""
+  companiesList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Company`."""
+    orderBy: [CompaniesOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CompanyCondition
+  ): [Company!]
+  beverage(id: Int!): Beverage
+  company(id: Int!): Company
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  listInclude(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+  ): BeveragesConnection
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  listIncludeList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Beverage]
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  listOmitConnection(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+  ): BeveragesConnection
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  listOmit(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Beverage]
+
+  """Reads a single `Beverage` using its globally unique `ID`."""
+  beverageByNodeId(
+    """The globally unique `ID` to be used in selecting a single `Beverage`."""
+    nodeId: ID!
+  ): Beverage
+
+  """Reads a single `Company` using its globally unique `ID`."""
+  companyByNodeId(
+    """The globally unique `ID` to be used in selecting a single `Company`."""
+    nodeId: ID!
+  ): Company
+}

--- a/tests/pg_omit_list_suffix/schema.sql
+++ b/tests/pg_omit_list_suffix/schema.sql
@@ -1,0 +1,34 @@
+create table companies (
+  id serial primary key,
+  name text not null
+);
+comment on table companies is E'@listSuffix include';
+
+create table beverages (
+  id serial primary key,
+  company_id int not null references companies,
+  distributor_id int references companies,
+  name text not null
+);
+comment on constraint "beverages_company_id_fkey" on "beverages" is E'@listSuffix include';
+-- @omitListSuffix has no effect when @foreignSimpleFieldName is set
+comment on constraint "beverages_distributor_id_fkey" on "beverages" is
+  E'@foreignFieldName distributedBeverages\n@foreignSimpleFieldName distributedBeveragesListing\n@listSuffix include';
+
+create function list_include() returns setof beverages as $$
+  select * from beverages;
+$$ language sql stable;
+comment on function list_include() is E'@listSuffix include';
+
+create function list_omit() returns setof beverages as $$
+  select * from beverages;
+$$ language sql stable;
+
+create function companies_computed_list_include(company companies) returns setof beverages as $$
+  select * from beverages;
+$$ language sql stable;
+comment on function companies_computed_list_include(companies) is E'@listSuffix include';
+
+create function companies_computed_list_omit(company companies) returns setof beverages as $$
+  select * from beverages;
+$$ language sql stable;

--- a/tests/pg_omit_list_suffix/schema.unsimplified.graphql
+++ b/tests/pg_omit_list_suffix/schema.unsimplified.graphql
@@ -1,0 +1,496 @@
+type Beverage implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  companyId: Int!
+  distributorId: Int
+  name: String!
+
+  """Reads a single `Company` that is related to this `Beverage`."""
+  companyByCompanyId: Company
+
+  """Reads a single `Company` that is related to this `Beverage`."""
+  companyByDistributorId: Company
+}
+
+"""
+A condition to be used against `Beverage` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input BeverageCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `companyId` field."""
+  companyId: Int
+
+  """Checks for equality with the object’s `distributorId` field."""
+  distributorId: Int
+
+  """Checks for equality with the object’s `name` field."""
+  name: String
+}
+
+"""A connection to a list of `Beverage` values."""
+type BeveragesConnection {
+  """A list of `Beverage` objects."""
+  nodes: [Beverage]!
+
+  """
+  A list of edges which contains the `Beverage` and cursor to aid in pagination.
+  """
+  edges: [BeveragesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Beverage` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Beverage` edge in the connection."""
+type BeveragesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Beverage` at the end of the edge."""
+  node: Beverage
+}
+
+"""Methods to use when ordering `Beverage`."""
+enum BeveragesOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  COMPANY_ID_ASC
+  COMPANY_ID_DESC
+  DISTRIBUTOR_ID_ASC
+  DISTRIBUTOR_ID_DESC
+  NAME_ASC
+  NAME_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""A connection to a list of `Company` values."""
+type CompaniesConnection {
+  """A list of `Company` objects."""
+  nodes: [Company]!
+
+  """
+  A list of edges which contains the `Company` and cursor to aid in pagination.
+  """
+  edges: [CompaniesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Company` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Company` edge in the connection."""
+type CompaniesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Company` at the end of the edge."""
+  node: Company
+}
+
+"""Methods to use when ordering `Company`."""
+enum CompaniesOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+type Company implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  name: String!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  beveragesByCompanyId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Beverage`."""
+    orderBy: [BeveragesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BeverageCondition
+  ): BeveragesConnection!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  beveragesByCompanyIdList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Beverage`."""
+    orderBy: [BeveragesOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BeverageCondition
+  ): [Beverage!]!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  distributedBeverages(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Beverage`."""
+    orderBy: [BeveragesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BeverageCondition
+  ): BeveragesConnection!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  distributedBeveragesListing(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Beverage`."""
+    orderBy: [BeveragesOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BeverageCondition
+  ): [Beverage!]!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  computedListInclude(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+  ): BeveragesConnection!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  computedListIncludeList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Beverage]
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  computedListOmit(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+  ): BeveragesConnection!
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  computedListOmitList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Beverage]
+}
+
+"""
+A condition to be used against `Company` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input CompanyCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `name` field."""
+  name: String
+}
+
+"""A location in a connection that can be used for resuming pagination."""
+scalar Cursor
+
+"""An object with a globally unique `ID`."""
+interface Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: Cursor
+
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+}
+
+"""The root query type which gives access points into the data universe."""
+type Query implements Node {
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
+
+  """
+  The root query type must be a `Node` to work well with Relay 1 mutations. This just resolves to `query`.
+  """
+  nodeId: ID!
+
+  """Fetches an object given its globally unique `ID`."""
+  node(
+    """The globally unique `ID`."""
+    nodeId: ID!
+  ): Node
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  allBeverages(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Beverage`."""
+    orderBy: [BeveragesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BeverageCondition
+  ): BeveragesConnection
+
+  """Reads a set of `Beverage`."""
+  allBeveragesList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Beverage`."""
+    orderBy: [BeveragesOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BeverageCondition
+  ): [Beverage!]
+
+  """Reads and enables pagination through a set of `Company`."""
+  allCompanies(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Company`."""
+    orderBy: [CompaniesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CompanyCondition
+  ): CompaniesConnection
+
+  """Reads a set of `Company`."""
+  allCompaniesList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Company`."""
+    orderBy: [CompaniesOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CompanyCondition
+  ): [Company!]
+  beverageById(id: Int!): Beverage
+  companyById(id: Int!): Company
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  listInclude(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+  ): BeveragesConnection
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  listIncludeList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Beverage]
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  listOmit(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+  ): BeveragesConnection
+
+  """Reads and enables pagination through a set of `Beverage`."""
+  listOmitList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Beverage]
+
+  """Reads a single `Beverage` using its globally unique `ID`."""
+  beverage(
+    """The globally unique `ID` to be used in selecting a single `Beverage`."""
+    nodeId: ID!
+  ): Beverage
+
+  """Reads a single `Company` using its globally unique `ID`."""
+  company(
+    """The globally unique `ID` to be used in selecting a single `Company`."""
+    nodeId: ID!
+  ): Company
+}

--- a/tests/pg_omit_list_suffix/settings.json
+++ b/tests/pg_omit_list_suffix/settings.json
@@ -1,0 +1,6 @@
+{
+  "disableDefaultMutations": true,
+  "graphileBuildOptions": {
+    "pgOmitListSuffix": true
+  }
+}


### PR DESCRIPTION

## Description

I've been using this as a patch for several months, and kept forgetting
to make a PR or open an issue about it. The use case is for when you are
*not* using `pgSimpleCollections = "only"` and `pgOmitListSuffix`, but
want to essentially apply those selectively.

I don't exactly remember the motivating case, or if it covers much
behavior.  Obviously needs tests, but throwing it out there for comment.

## Performance impact

Looks like it has a small perf impact, it adds a couple of ternary expressions.

## Security impact

unknown

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.
