### PR TITLE
BREAKING: Simplify foreign keys that are also primary keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -295,6 +295,13 @@ function PgSimplifyInflectorPlugin(
         if (base) {
           return base + ConnectionSuffix(constraint);
         }
+        if (isPrimaryKey(detailedKeys, table)) {
+          return (
+            this.camelCase(
+              `${this.distinctPluralize(this._singularizedTableName(table))}`
+            ) + ConnectionSuffix(constraint)
+          );
+        }
         return (
           oldInflection.manyRelationByKeys(
             detailedKeys,
@@ -324,7 +331,7 @@ function PgSimplifyInflectorPlugin(
           return (
             this.camelCase(
               `${this.distinctPluralize(this._singularizedTableName(table))}`
-            ) + ConnectionSuffix(constraint)
+            ) + ListSuffix(constraint)
           );
         }
         return (

--- a/index.ts
+++ b/index.ts
@@ -347,6 +347,13 @@ function PgSimplifyInflectorPlugin(
         if (base) {
           return base + ConnectionSuffix(constraint);
         }
+        if (isPrimaryKey(detailedKeys, table)) {
+          return (
+            this.camelCase(
+              `${this.distinctPluralize(this._singularizedTableName(table))}`
+            ) + ConnectionSuffix(constraint)
+          );
+        }
         return (
           oldInflection.manyRelationByKeys(
             detailedKeys,
@@ -382,7 +389,7 @@ function PgSimplifyInflectorPlugin(
           return (
             this.camelCase(
               `${this.distinctPluralize(this._singularizedTableName(table))}`
-            ) + ConnectionSuffix(constraint)
+            ) + ListSuffix(constraint)
           );
         }
         return (

--- a/tests/animal/schema.graphql.diff
+++ b/tests/animal/schema.graphql.diff
@@ -1,0 +1,378 @@
+--- unsimplified
++++ simplified
+@@ -6,10 +6,10 @@
+   id: Int!
+ 
+   """Reads a single `Dog` that is related to this `Animal`."""
+-  dogById: Dog
++  dog: Dog
+ 
+   """Reads and enables pagination through a set of `Dog`."""
+-  dogsById(
++  dogs(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -35,7 +35,7 @@
+     A condition to be used in determining which values should be returned by the collection.
+     """
+     condition: DogCondition
+-  ): DogsConnection! @deprecated(reason: "Please use dogById instead")
++  ): DogsConnection! @deprecated(reason: "Please use dog instead")
+ }
+ 
+ """
+@@ -157,7 +157,7 @@
+   query: Query
+ 
+   """Reads a single `Animal` that is related to this `Dog`."""
+-  animalById: Animal
++  animal: Animal
+ 
+   """An edge for our `Dog`. May be used by Relay 1."""
+   dogEdge(
+@@ -169,14 +169,18 @@
+ """A location in a connection that can be used for resuming pagination."""
+ scalar Cursor
+ 
+-"""All input for the `deleteAnimalById` mutation."""
+-input DeleteAnimalByIdInput {
++"""All input for the `deleteAnimalByNodeId` mutation."""
++input DeleteAnimalByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-  id: Int!
++
++  """
++  The globally unique `ID` which will identify a single `Animal` to be deleted.
++  """
++  nodeId: ID!
+ }
+ 
+ """All input for the `deleteAnimal` mutation."""
+@@ -186,11 +190,7 @@
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-
+-  """
+-  The globally unique `ID` which will identify a single `Animal` to be deleted.
+-  """
+-  nodeId: ID!
++  id: Int!
+ }
+ 
+ """The output of our delete `Animal` mutation."""
+@@ -203,7 +203,7 @@
+ 
+   """The `Animal` that was deleted by this mutation."""
+   animal: Animal
+-  deletedAnimalId: ID
++  deletedAnimalNodeId: ID
+ 
+   """
+   Our root query field type. Allows us to run any query from our mutation payload.
+@@ -217,14 +217,18 @@
+   ): AnimalsEdge
+ }
+ 
+-"""All input for the `deleteDogById` mutation."""
+-input DeleteDogByIdInput {
++"""All input for the `deleteDogByNodeId` mutation."""
++input DeleteDogByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-  id: Int!
++
++  """
++  The globally unique `ID` which will identify a single `Dog` to be deleted.
++  """
++  nodeId: ID!
+ }
+ 
+ """All input for the `deleteDog` mutation."""
+@@ -234,11 +238,7 @@
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-
+-  """
+-  The globally unique `ID` which will identify a single `Dog` to be deleted.
+-  """
+-  nodeId: ID!
++  id: Int!
+ }
+ 
+ """The output of our delete `Dog` mutation."""
+@@ -251,7 +251,7 @@
+ 
+   """The `Dog` that was deleted by this mutation."""
+   dog: Dog
+-  deletedDogId: ID
++  deletedDogNodeId: ID
+ 
+   """
+   Our root query field type. Allows us to run any query from our mutation payload.
+@@ -259,7 +259,7 @@
+   query: Query
+ 
+   """Reads a single `Animal` that is related to this `Dog`."""
+-  animalById: Animal
++  animal: Animal
+ 
+   """An edge for our `Dog`. May be used by Relay 1."""
+   dogEdge(
+@@ -276,7 +276,7 @@
+   id: Int!
+ 
+   """Reads a single `Animal` that is related to this `Dog`."""
+-  animalById: Animal
++  animal: Animal
+ }
+ 
+ """
+@@ -353,67 +353,67 @@
+   ): CreateDogPayload
+ 
+   """Updates a single `Animal` using its globally unique id and a patch."""
+-  updateAnimal(
++  updateAnimalByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateAnimalInput!
++    input: UpdateAnimalByNodeIdInput!
+   ): UpdateAnimalPayload
+ 
+   """Updates a single `Animal` using a unique key and a patch."""
+-  updateAnimalById(
++  updateAnimal(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateAnimalByIdInput!
++    input: UpdateAnimalInput!
+   ): UpdateAnimalPayload
+ 
+   """Updates a single `Dog` using its globally unique id and a patch."""
+-  updateDog(
++  updateDogByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateDogInput!
++    input: UpdateDogByNodeIdInput!
+   ): UpdateDogPayload
+ 
+   """Updates a single `Dog` using a unique key and a patch."""
+-  updateDogById(
++  updateDog(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateDogByIdInput!
++    input: UpdateDogInput!
+   ): UpdateDogPayload
+ 
+   """Deletes a single `Animal` using its globally unique id."""
+-  deleteAnimal(
++  deleteAnimalByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteAnimalInput!
++    input: DeleteAnimalByNodeIdInput!
+   ): DeleteAnimalPayload
+ 
+   """Deletes a single `Animal` using a unique key."""
+-  deleteAnimalById(
++  deleteAnimal(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteAnimalByIdInput!
++    input: DeleteAnimalInput!
+   ): DeleteAnimalPayload
+ 
+   """Deletes a single `Dog` using its globally unique id."""
+-  deleteDog(
++  deleteDogByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteDogInput!
++    input: DeleteDogByNodeIdInput!
+   ): DeleteDogPayload
+ 
+   """Deletes a single `Dog` using a unique key."""
+-  deleteDogById(
++  deleteDog(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteDogByIdInput!
++    input: DeleteDogInput!
+   ): DeleteDogPayload
+ }
+ 
+@@ -460,7 +460,7 @@
+   ): Node
+ 
+   """Reads and enables pagination through a set of `Animal`."""
+-  allAnimals(
++  animals(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -489,7 +489,7 @@
+   ): AnimalsConnection
+ 
+   """Reads a set of `Animal`."""
+-  allAnimalsList(
++  animalsList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -506,7 +506,7 @@
+   ): [Animal!]
+ 
+   """Reads and enables pagination through a set of `Dog`."""
+-  allDogs(
++  dogs(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -535,7 +535,7 @@
+   ): DogsConnection
+ 
+   """Reads a set of `Dog`."""
+-  allDogsList(
++  dogsList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -550,24 +550,24 @@
+     """
+     condition: DogCondition
+   ): [Dog!]
+-  animalById(id: Int!): Animal
+-  dogById(id: Int!): Dog
++  animal(id: Int!): Animal
++  dog(id: Int!): Dog
+ 
+   """Reads a single `Animal` using its globally unique `ID`."""
+-  animal(
++  animalByNodeId(
+     """The globally unique `ID` to be used in selecting a single `Animal`."""
+     nodeId: ID!
+   ): Animal
+ 
+   """Reads a single `Dog` using its globally unique `ID`."""
+-  dog(
++  dogByNodeId(
+     """The globally unique `ID` to be used in selecting a single `Dog`."""
+     nodeId: ID!
+   ): Dog
+ }
+ 
+-"""All input for the `updateAnimalById` mutation."""
+-input UpdateAnimalByIdInput {
++"""All input for the `updateAnimalByNodeId` mutation."""
++input UpdateAnimalByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+@@ -575,10 +575,14 @@
+   clientMutationId: String
+ 
+   """
++  The globally unique `ID` which will identify a single `Animal` to be updated.
++  """
++  nodeId: ID!
++
++  """
+   An object where the defined keys will be set on the `Animal` being updated.
+   """
+-  animalPatch: AnimalPatch!
+-  id: Int!
++  patch: AnimalPatch!
+ }
+ 
+ """All input for the `updateAnimal` mutation."""
+@@ -590,14 +594,10 @@
+   clientMutationId: String
+ 
+   """
+-  The globally unique `ID` which will identify a single `Animal` to be updated.
+-  """
+-  nodeId: ID!
+-
+-  """
+   An object where the defined keys will be set on the `Animal` being updated.
+   """
+-  animalPatch: AnimalPatch!
++  patch: AnimalPatch!
++  id: Int!
+ }
+ 
+ """The output of our update `Animal` mutation."""
+@@ -623,8 +623,8 @@
+   ): AnimalsEdge
+ }
+ 
+-"""All input for the `updateDogById` mutation."""
+-input UpdateDogByIdInput {
++"""All input for the `updateDogByNodeId` mutation."""
++input UpdateDogByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+@@ -632,10 +632,14 @@
+   clientMutationId: String
+ 
+   """
++  The globally unique `ID` which will identify a single `Dog` to be updated.
++  """
++  nodeId: ID!
++
++  """
+   An object where the defined keys will be set on the `Dog` being updated.
+   """
+-  dogPatch: DogPatch!
+-  id: Int!
++  patch: DogPatch!
+ }
+ 
+ """All input for the `updateDog` mutation."""
+@@ -647,14 +651,10 @@
+   clientMutationId: String
+ 
+   """
+-  The globally unique `ID` which will identify a single `Dog` to be updated.
+-  """
+-  nodeId: ID!
+-
+-  """
+   An object where the defined keys will be set on the `Dog` being updated.
+   """
+-  dogPatch: DogPatch!
++  patch: DogPatch!
++  id: Int!
+ }
+ 
+ """The output of our update `Dog` mutation."""
+@@ -674,7 +674,7 @@
+   query: Query
+ 
+   """Reads a single `Animal` that is related to this `Dog`."""
+-  animalById: Animal
++  animal: Animal
+ 
+   """An edge for our `Dog`. May be used by Relay 1."""
+   dogEdge(

--- a/tests/animal/schema.graphql.diff
+++ b/tests/animal/schema.graphql.diff
@@ -1,6 +1,6 @@
 --- unsimplified
 +++ simplified
-@@ -6,10 +6,10 @@
+@@ -6,7 +6,7 @@
    id: Int!
  
    """Reads a single `Dog` that is related to this `Animal`."""
@@ -8,21 +8,65 @@
 +  dog: Dog
  
    """Reads and enables pagination through a set of `Dog`."""
--  dogsById(
-+  dogs(
-     """Only read the first `n` values of the set."""
-     first: Int
- 
-@@ -35,7 +35,7 @@
+   dogsById(
+@@ -35,10 +35,10 @@
      A condition to be used in determining which values should be returned by the collection.
      """
      condition: DogCondition
 -  ): DogsConnection! @deprecated(reason: "Please use dogById instead")
 +  ): DogsConnection! @deprecated(reason: "Please use dog instead")
+ 
+   """Reads a single `Cat` that is related to this `Animal`."""
+-  catById: Cat
++  cat: Cat
+ 
+   """Reads and enables pagination through a set of `Cat`."""
+   catsById(
+@@ -67,13 +67,13 @@
+     A condition to be used in determining which values should be returned by the collection.
+     """
+     condition: CatCondition
+-  ): CatsConnection! @deprecated(reason: "Please use catById instead")
++  ): CatsConnection! @deprecated(reason: "Please use cat instead")
+ 
+   """Reads a single `Gerbil` that is related to this `Animal`."""
+-  gerbilByAnimalId: Gerbil
++  gerbil: Gerbil
+ 
+   """Reads and enables pagination through a set of `Gerbil`."""
+-  gerbilsByAnimalId(
++  gerbils(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -99,7 +99,7 @@
+     A condition to be used in determining which values should be returned by the collection.
+     """
+     condition: GerbilCondition
+-  ): GerbilsConnection! @deprecated(reason: "Please use gerbilByAnimalId instead")
++  ): GerbilsConnection! @deprecated(reason: "Please use gerbil instead")
  }
  
  """
-@@ -157,7 +157,7 @@
+@@ -165,7 +165,7 @@
+   id: Int!
+ 
+   """Reads a single `Animal` that is related to this `Cat`."""
+-  animalById: Animal
++  animal: Animal
+ }
+ 
+ """
+@@ -285,7 +285,7 @@
+   query: Query
+ 
+   """Reads a single `Animal` that is related to this `Cat`."""
+-  animalById: Animal
++  animal: Animal
+ 
+   """An edge for our `Cat`. May be used by Relay 1."""
+   catEdge(
+@@ -323,7 +323,7 @@
    query: Query
  
    """Reads a single `Animal` that is related to this `Dog`."""
@@ -31,7 +75,16 @@
  
    """An edge for our `Dog`. May be used by Relay 1."""
    dogEdge(
-@@ -169,14 +169,18 @@
+@@ -361,7 +361,7 @@
+   query: Query
+ 
+   """Reads a single `Animal` that is related to this `Gerbil`."""
+-  animalByAnimalId: Animal
++  animal: Animal
+ 
+   """An edge for our `Gerbil`. May be used by Relay 1."""
+   gerbilEdge(
+@@ -373,14 +373,18 @@
  """A location in a connection that can be used for resuming pagination."""
  scalar Cursor
  
@@ -53,7 +106,7 @@
  }
  
  """All input for the `deleteAnimal` mutation."""
-@@ -186,11 +190,7 @@
+@@ -390,11 +394,7 @@
    payload verbatim. May be used to track mutations by the client.
    """
    clientMutationId: String
@@ -66,7 +119,7 @@
  }
  
  """The output of our delete `Animal` mutation."""
-@@ -203,7 +203,7 @@
+@@ -407,7 +407,7 @@
  
    """The `Animal` that was deleted by this mutation."""
    animal: Animal
@@ -75,8 +128,61 @@
  
    """
    Our root query field type. Allows us to run any query from our mutation payload.
-@@ -217,14 +217,18 @@
+@@ -421,14 +421,18 @@
    ): AnimalsEdge
+ }
+ 
+-"""All input for the `deleteCatById` mutation."""
+-input DeleteCatByIdInput {
++"""All input for the `deleteCatByNodeId` mutation."""
++input DeleteCatByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-  id: Int!
++
++  """
++  The globally unique `ID` which will identify a single `Cat` to be deleted.
++  """
++  nodeId: ID!
+ }
+ 
+ """All input for the `deleteCat` mutation."""
+@@ -438,11 +442,7 @@
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-
+-  """
+-  The globally unique `ID` which will identify a single `Cat` to be deleted.
+-  """
+-  nodeId: ID!
++  id: Int!
+ }
+ 
+ """The output of our delete `Cat` mutation."""
+@@ -455,7 +455,7 @@
+ 
+   """The `Cat` that was deleted by this mutation."""
+   cat: Cat
+-  deletedCatId: ID
++  deletedCatNodeId: ID
+ 
+   """
+   Our root query field type. Allows us to run any query from our mutation payload.
+@@ -463,7 +463,7 @@
+   query: Query
+ 
+   """Reads a single `Animal` that is related to this `Cat`."""
+-  animalById: Animal
++  animal: Animal
+ 
+   """An edge for our `Cat`. May be used by Relay 1."""
+   catEdge(
+@@ -472,14 +472,18 @@
+   ): CatsEdge
  }
  
 -"""All input for the `deleteDogById` mutation."""
@@ -97,7 +203,7 @@
  }
  
  """All input for the `deleteDog` mutation."""
-@@ -234,11 +238,7 @@
+@@ -489,11 +493,7 @@
    payload verbatim. May be used to track mutations by the client.
    """
    clientMutationId: String
@@ -110,7 +216,7 @@
  }
  
  """The output of our delete `Dog` mutation."""
-@@ -251,7 +251,7 @@
+@@ -506,7 +506,7 @@
  
    """The `Dog` that was deleted by this mutation."""
    dog: Dog
@@ -119,7 +225,7 @@
  
    """
    Our root query field type. Allows us to run any query from our mutation payload.
-@@ -259,7 +259,7 @@
+@@ -514,7 +514,7 @@
    query: Query
  
    """Reads a single `Animal` that is related to this `Dog`."""
@@ -128,7 +234,60 @@
  
    """An edge for our `Dog`. May be used by Relay 1."""
    dogEdge(
-@@ -276,7 +276,7 @@
+@@ -523,14 +523,18 @@
+   ): DogsEdge
+ }
+ 
+-"""All input for the `deleteGerbilByAnimalId` mutation."""
+-input DeleteGerbilByAnimalIdInput {
++"""All input for the `deleteGerbilByNodeId` mutation."""
++input DeleteGerbilByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-  animalId: Int!
++
++  """
++  The globally unique `ID` which will identify a single `Gerbil` to be deleted.
++  """
++  nodeId: ID!
+ }
+ 
+ """All input for the `deleteGerbil` mutation."""
+@@ -540,11 +544,7 @@
+   payload verbatim. May be used to track mutations by the client.
+   """
+   clientMutationId: String
+-
+-  """
+-  The globally unique `ID` which will identify a single `Gerbil` to be deleted.
+-  """
+-  nodeId: ID!
++  animalId: Int!
+ }
+ 
+ """The output of our delete `Gerbil` mutation."""
+@@ -557,7 +557,7 @@
+ 
+   """The `Gerbil` that was deleted by this mutation."""
+   gerbil: Gerbil
+-  deletedGerbilId: ID
++  deletedGerbilNodeId: ID
+ 
+   """
+   Our root query field type. Allows us to run any query from our mutation payload.
+@@ -565,7 +565,7 @@
+   query: Query
+ 
+   """Reads a single `Animal` that is related to this `Gerbil`."""
+-  animalByAnimalId: Animal
++  animal: Animal
+ 
+   """An edge for our `Gerbil`. May be used by Relay 1."""
+   gerbilEdge(
+@@ -582,7 +582,7 @@
    id: Int!
  
    """Reads a single `Animal` that is related to this `Dog`."""
@@ -137,8 +296,17 @@
  }
  
  """
-@@ -353,67 +353,67 @@
-   ): CreateDogPayload
+@@ -646,7 +646,7 @@
+   animalId: Int!
+ 
+   """Reads a single `Animal` that is related to this `Gerbil`."""
+-  animalByAnimalId: Animal
++  animal: Animal
+ }
+ 
+ """
+@@ -741,131 +741,131 @@
+   ): CreateGerbilPayload
  
    """Updates a single `Animal` using its globally unique id and a patch."""
 -  updateAnimal(
@@ -160,6 +328,26 @@
 +    input: UpdateAnimalInput!
    ): UpdateAnimalPayload
  
+   """Updates a single `Cat` using its globally unique id and a patch."""
+-  updateCat(
++  updateCatByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateCatInput!
++    input: UpdateCatByNodeIdInput!
+   ): UpdateCatPayload
+ 
+   """Updates a single `Cat` using a unique key and a patch."""
+-  updateCatById(
++  updateCat(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateCatByIdInput!
++    input: UpdateCatInput!
+   ): UpdateCatPayload
+ 
    """Updates a single `Dog` using its globally unique id and a patch."""
 -  updateDog(
 +  updateDogByNodeId(
@@ -179,6 +367,26 @@
 -    input: UpdateDogByIdInput!
 +    input: UpdateDogInput!
    ): UpdateDogPayload
+ 
+   """Updates a single `Gerbil` using its globally unique id and a patch."""
+-  updateGerbil(
++  updateGerbilByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateGerbilInput!
++    input: UpdateGerbilByNodeIdInput!
+   ): UpdateGerbilPayload
+ 
+   """Updates a single `Gerbil` using a unique key and a patch."""
+-  updateGerbilByAnimalId(
++  updateGerbil(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: UpdateGerbilByAnimalIdInput!
++    input: UpdateGerbilInput!
+   ): UpdateGerbilPayload
  
    """Deletes a single `Animal` using its globally unique id."""
 -  deleteAnimal(
@@ -200,6 +408,26 @@
 +    input: DeleteAnimalInput!
    ): DeleteAnimalPayload
  
+   """Deletes a single `Cat` using its globally unique id."""
+-  deleteCat(
++  deleteCatByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteCatInput!
++    input: DeleteCatByNodeIdInput!
+   ): DeleteCatPayload
+ 
+   """Deletes a single `Cat` using a unique key."""
+-  deleteCatById(
++  deleteCat(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteCatByIdInput!
++    input: DeleteCatInput!
+   ): DeleteCatPayload
+ 
    """Deletes a single `Dog` using its globally unique id."""
 -  deleteDog(
 +  deleteDogByNodeId(
@@ -219,9 +447,29 @@
 -    input: DeleteDogByIdInput!
 +    input: DeleteDogInput!
    ): DeleteDogPayload
+ 
+   """Deletes a single `Gerbil` using its globally unique id."""
+-  deleteGerbil(
++  deleteGerbilByNodeId(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteGerbilInput!
++    input: DeleteGerbilByNodeIdInput!
+   ): DeleteGerbilPayload
+ 
+   """Deletes a single `Gerbil` using a unique key."""
+-  deleteGerbilByAnimalId(
++  deleteGerbil(
+     """
+     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+     """
+-    input: DeleteGerbilByAnimalIdInput!
++    input: DeleteGerbilInput!
+   ): DeleteGerbilPayload
  }
  
-@@ -460,7 +460,7 @@
+@@ -912,7 +912,7 @@
    ): Node
  
    """Reads and enables pagination through a set of `Animal`."""
@@ -230,7 +478,7 @@
      """Only read the first `n` values of the set."""
      first: Int
  
-@@ -489,7 +489,7 @@
+@@ -941,7 +941,7 @@
    ): AnimalsConnection
  
    """Reads a set of `Animal`."""
@@ -239,8 +487,26 @@
      """Only read the first `n` values of the set."""
      first: Int
  
-@@ -506,7 +506,7 @@
+@@ -958,7 +958,7 @@
    ): [Animal!]
+ 
+   """Reads and enables pagination through a set of `Cat`."""
+-  allCats(
++  cats(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -987,7 +987,7 @@
+   ): CatsConnection
+ 
+   """Reads a set of `Cat`."""
+-  allCatsList(
++  catsList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1004,7 +1004,7 @@
+   ): [Cat!]
  
    """Reads and enables pagination through a set of `Dog`."""
 -  allDogs(
@@ -248,7 +514,7 @@
      """Only read the first `n` values of the set."""
      first: Int
  
-@@ -535,7 +535,7 @@
+@@ -1033,7 +1033,7 @@
    ): DogsConnection
  
    """Reads a set of `Dog`."""
@@ -257,14 +523,36 @@
      """Only read the first `n` values of the set."""
      first: Int
  
-@@ -550,24 +550,24 @@
-     """
-     condition: DogCondition
+@@ -1050,7 +1050,7 @@
    ): [Dog!]
+ 
+   """Reads and enables pagination through a set of `Gerbil`."""
+-  allGerbils(
++  gerbils(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1079,7 +1079,7 @@
+   ): GerbilsConnection
+ 
+   """Reads a set of `Gerbil`."""
+-  allGerbilsList(
++  gerbilsList(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -1094,38 +1094,38 @@
+     """
+     condition: GerbilCondition
+   ): [Gerbil!]
 -  animalById(id: Int!): Animal
+-  catById(id: Int!): Cat
 -  dogById(id: Int!): Dog
+-  gerbilByAnimalId(animalId: Int!): Gerbil
 +  animal(id: Int!): Animal
++  cat(id: Int!): Cat
 +  dog(id: Int!): Dog
++  gerbil(animalId: Int!): Gerbil
  
    """Reads a single `Animal` using its globally unique `ID`."""
 -  animal(
@@ -273,12 +561,26 @@
      nodeId: ID!
    ): Animal
  
+   """Reads a single `Cat` using its globally unique `ID`."""
+-  cat(
++  catByNodeId(
+     """The globally unique `ID` to be used in selecting a single `Cat`."""
+     nodeId: ID!
+   ): Cat
+ 
    """Reads a single `Dog` using its globally unique `ID`."""
 -  dog(
 +  dogByNodeId(
      """The globally unique `ID` to be used in selecting a single `Dog`."""
      nodeId: ID!
    ): Dog
+ 
+   """Reads a single `Gerbil` using its globally unique `ID`."""
+-  gerbil(
++  gerbilByNodeId(
+     """The globally unique `ID` to be used in selecting a single `Gerbil`."""
+     nodeId: ID!
+   ): Gerbil
  }
  
 -"""All input for the `updateAnimalById` mutation."""
@@ -288,7 +590,7 @@
    """
    An arbitrary string value with no semantic meaning. Will be included in the
    payload verbatim. May be used to track mutations by the client.
-@@ -575,10 +575,14 @@
+@@ -1133,10 +1133,14 @@
    clientMutationId: String
  
    """
@@ -305,7 +607,7 @@
  }
  
  """All input for the `updateAnimal` mutation."""
-@@ -590,14 +594,10 @@
+@@ -1148,14 +1152,10 @@
    clientMutationId: String
  
    """
@@ -322,8 +624,62 @@
  }
  
  """The output of our update `Animal` mutation."""
-@@ -623,8 +623,8 @@
+@@ -1181,8 +1181,8 @@
    ): AnimalsEdge
+ }
+ 
+-"""All input for the `updateCatById` mutation."""
+-input UpdateCatByIdInput {
++"""All input for the `updateCatByNodeId` mutation."""
++input UpdateCatByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+@@ -1190,10 +1190,14 @@
+   clientMutationId: String
+ 
+   """
++  The globally unique `ID` which will identify a single `Cat` to be updated.
++  """
++  nodeId: ID!
++
++  """
+   An object where the defined keys will be set on the `Cat` being updated.
+   """
+-  catPatch: CatPatch!
+-  id: Int!
++  patch: CatPatch!
+ }
+ 
+ """All input for the `updateCat` mutation."""
+@@ -1205,14 +1209,10 @@
+   clientMutationId: String
+ 
+   """
+-  The globally unique `ID` which will identify a single `Cat` to be updated.
+-  """
+-  nodeId: ID!
+-
+-  """
+   An object where the defined keys will be set on the `Cat` being updated.
+   """
+-  catPatch: CatPatch!
++  patch: CatPatch!
++  id: Int!
+ }
+ 
+ """The output of our update `Cat` mutation."""
+@@ -1232,7 +1232,7 @@
+   query: Query
+ 
+   """Reads a single `Animal` that is related to this `Cat`."""
+-  animalById: Animal
++  animal: Animal
+ 
+   """An edge for our `Cat`. May be used by Relay 1."""
+   catEdge(
+@@ -1241,8 +1241,8 @@
+   ): CatsEdge
  }
  
 -"""All input for the `updateDogById` mutation."""
@@ -333,7 +689,7 @@
    """
    An arbitrary string value with no semantic meaning. Will be included in the
    payload verbatim. May be used to track mutations by the client.
-@@ -632,10 +632,14 @@
+@@ -1250,10 +1250,14 @@
    clientMutationId: String
  
    """
@@ -350,7 +706,7 @@
  }
  
  """All input for the `updateDog` mutation."""
-@@ -647,14 +651,10 @@
+@@ -1265,14 +1269,10 @@
    clientMutationId: String
  
    """
@@ -367,7 +723,7 @@
  }
  
  """The output of our update `Dog` mutation."""
-@@ -674,7 +674,7 @@
+@@ -1292,7 +1292,7 @@
    query: Query
  
    """Reads a single `Animal` that is related to this `Dog`."""
@@ -376,3 +732,57 @@
  
    """An edge for our `Dog`. May be used by Relay 1."""
    dogEdge(
+@@ -1301,8 +1301,8 @@
+   ): DogsEdge
+ }
+ 
+-"""All input for the `updateGerbilByAnimalId` mutation."""
+-input UpdateGerbilByAnimalIdInput {
++"""All input for the `updateGerbilByNodeId` mutation."""
++input UpdateGerbilByNodeIdInput {
+   """
+   An arbitrary string value with no semantic meaning. Will be included in the
+   payload verbatim. May be used to track mutations by the client.
+@@ -1310,10 +1310,14 @@
+   clientMutationId: String
+ 
+   """
++  The globally unique `ID` which will identify a single `Gerbil` to be updated.
++  """
++  nodeId: ID!
++
++  """
+   An object where the defined keys will be set on the `Gerbil` being updated.
+   """
+-  gerbilPatch: GerbilPatch!
+-  animalId: Int!
++  patch: GerbilPatch!
+ }
+ 
+ """All input for the `updateGerbil` mutation."""
+@@ -1325,14 +1329,10 @@
+   clientMutationId: String
+ 
+   """
+-  The globally unique `ID` which will identify a single `Gerbil` to be updated.
+-  """
+-  nodeId: ID!
+-
+-  """
+   An object where the defined keys will be set on the `Gerbil` being updated.
+   """
+-  gerbilPatch: GerbilPatch!
++  patch: GerbilPatch!
++  animalId: Int!
+ }
+ 
+ """The output of our update `Gerbil` mutation."""
+@@ -1352,7 +1352,7 @@
+   query: Query
+ 
+   """Reads a single `Animal` that is related to this `Gerbil`."""
+-  animalByAnimalId: Animal
++  animal: Animal
+ 
+   """An edge for our `Gerbil`. May be used by Relay 1."""
+   gerbilEdge(

--- a/tests/animal/schema.graphql.diff
+++ b/tests/animal/schema.graphql.diff
@@ -1,6 +1,6 @@
 --- unsimplified
 +++ simplified
-@@ -6,7 +6,7 @@
+@@ -6,10 +6,10 @@
    id: Int!
  
    """Reads a single `Dog` that is related to this `Animal`."""
@@ -8,8 +8,12 @@
 +  dog: Dog
  
    """Reads and enables pagination through a set of `Dog`."""
-   dogsById(
-@@ -35,10 +35,10 @@
+-  dogsById(
++  dogs(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
+@@ -35,13 +35,13 @@
      A condition to be used in determining which values should be returned by the collection.
      """
      condition: DogCondition
@@ -21,7 +25,11 @@
 +  cat: Cat
  
    """Reads and enables pagination through a set of `Cat`."""
-   catsById(
+-  catsById(
++  cats(
+     """Only read the first `n` values of the set."""
+     first: Int
+ 
 @@ -67,13 +67,13 @@
      A condition to be used in determining which values should be returned by the collection.
      """

--- a/tests/animal/schema.simplified.graphql
+++ b/tests/animal/schema.simplified.graphql
@@ -9,7 +9,7 @@ type Animal implements Node {
   dog: Dog
 
   """Reads and enables pagination through a set of `Dog`."""
-  dogs(
+  dogsById(
     """Only read the first `n` values of the set."""
     first: Int
 
@@ -36,6 +36,70 @@ type Animal implements Node {
     """
     condition: DogCondition
   ): DogsConnection! @deprecated(reason: "Please use dog instead")
+
+  """Reads a single `Cat` that is related to this `Animal`."""
+  cat: Cat
+
+  """Reads and enables pagination through a set of `Cat`."""
+  catsById(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Cat`."""
+    orderBy: [CatsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CatCondition
+  ): CatsConnection! @deprecated(reason: "Please use cat instead")
+
+  """Reads a single `Gerbil` that is related to this `Animal`."""
+  gerbil: Gerbil
+
+  """Reads and enables pagination through a set of `Gerbil`."""
+  gerbils(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Gerbil`."""
+    orderBy: [GerbilsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GerbilCondition
+  ): GerbilsConnection! @deprecated(reason: "Please use gerbil instead")
 }
 
 """
@@ -93,6 +157,70 @@ enum AnimalsOrderBy {
   PRIMARY_KEY_DESC
 }
 
+type Cat implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+
+  """Reads a single `Animal` that is related to this `Cat`."""
+  animal: Animal
+}
+
+"""
+A condition to be used against `Cat` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input CatCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+}
+
+"""An input for mutations affecting `Cat`"""
+input CatInput {
+  id: Int!
+}
+
+"""Represents an update to a `Cat`. Fields that are set will be updated."""
+input CatPatch {
+  id: Int
+}
+
+"""A connection to a list of `Cat` values."""
+type CatsConnection {
+  """A list of `Cat` objects."""
+  nodes: [Cat]!
+
+  """
+  A list of edges which contains the `Cat` and cursor to aid in pagination.
+  """
+  edges: [CatsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Cat` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Cat` edge in the connection."""
+type CatsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Cat` at the end of the edge."""
+  node: Cat
+}
+
+"""Methods to use when ordering `Cat`."""
+enum CatsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
 """All input for the create `Animal` mutation."""
 input CreateAnimalInput {
   """
@@ -126,6 +254,44 @@ type CreateAnimalPayload {
     """The method to use when ordering `Animal`."""
     orderBy: [AnimalsOrderBy!] = [PRIMARY_KEY_ASC]
   ): AnimalsEdge
+}
+
+"""All input for the create `Cat` mutation."""
+input CreateCatInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `Cat` to be created by this mutation."""
+  cat: CatInput!
+}
+
+"""The output of our create `Cat` mutation."""
+type CreateCatPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Cat` that was created by this mutation."""
+  cat: Cat
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single `Animal` that is related to this `Cat`."""
+  animal: Animal
+
+  """An edge for our `Cat`. May be used by Relay 1."""
+  catEdge(
+    """The method to use when ordering `Cat`."""
+    orderBy: [CatsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CatsEdge
 }
 
 """All input for the create `Dog` mutation."""
@@ -164,6 +330,44 @@ type CreateDogPayload {
     """The method to use when ordering `Dog`."""
     orderBy: [DogsOrderBy!] = [PRIMARY_KEY_ASC]
   ): DogsEdge
+}
+
+"""All input for the create `Gerbil` mutation."""
+input CreateGerbilInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `Gerbil` to be created by this mutation."""
+  gerbil: GerbilInput!
+}
+
+"""The output of our create `Gerbil` mutation."""
+type CreateGerbilPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Gerbil` that was created by this mutation."""
+  gerbil: Gerbil
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single `Animal` that is related to this `Gerbil`."""
+  animal: Animal
+
+  """An edge for our `Gerbil`. May be used by Relay 1."""
+  gerbilEdge(
+    """The method to use when ordering `Gerbil`."""
+    orderBy: [GerbilsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): GerbilsEdge
 }
 
 """A location in a connection that can be used for resuming pagination."""
@@ -217,6 +421,57 @@ type DeleteAnimalPayload {
   ): AnimalsEdge
 }
 
+"""All input for the `deleteCatByNodeId` mutation."""
+input DeleteCatByNodeIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Cat` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""All input for the `deleteCat` mutation."""
+input DeleteCatInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""The output of our delete `Cat` mutation."""
+type DeleteCatPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Cat` that was deleted by this mutation."""
+  cat: Cat
+  deletedCatNodeId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single `Animal` that is related to this `Cat`."""
+  animal: Animal
+
+  """An edge for our `Cat`. May be used by Relay 1."""
+  catEdge(
+    """The method to use when ordering `Cat`."""
+    orderBy: [CatsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CatsEdge
+}
+
 """All input for the `deleteDogByNodeId` mutation."""
 input DeleteDogByNodeIdInput {
   """
@@ -266,6 +521,57 @@ type DeleteDogPayload {
     """The method to use when ordering `Dog`."""
     orderBy: [DogsOrderBy!] = [PRIMARY_KEY_ASC]
   ): DogsEdge
+}
+
+"""All input for the `deleteGerbilByNodeId` mutation."""
+input DeleteGerbilByNodeIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Gerbil` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""All input for the `deleteGerbil` mutation."""
+input DeleteGerbilInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  animalId: Int!
+}
+
+"""The output of our delete `Gerbil` mutation."""
+type DeleteGerbilPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Gerbil` that was deleted by this mutation."""
+  gerbil: Gerbil
+  deletedGerbilNodeId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single `Animal` that is related to this `Gerbil`."""
+  animal: Animal
+
+  """An edge for our `Gerbil`. May be used by Relay 1."""
+  gerbilEdge(
+    """The method to use when ordering `Gerbil`."""
+    orderBy: [GerbilsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): GerbilsEdge
 }
 
 type Dog implements Node {
@@ -332,6 +638,72 @@ enum DogsOrderBy {
   PRIMARY_KEY_DESC
 }
 
+type Gerbil implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  animalId: Int!
+
+  """Reads a single `Animal` that is related to this `Gerbil`."""
+  animal: Animal
+}
+
+"""
+A condition to be used against `Gerbil` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input GerbilCondition {
+  """Checks for equality with the object’s `animalId` field."""
+  animalId: Int
+}
+
+"""An input for mutations affecting `Gerbil`"""
+input GerbilInput {
+  animalId: Int!
+}
+
+"""
+Represents an update to a `Gerbil`. Fields that are set will be updated.
+"""
+input GerbilPatch {
+  animalId: Int
+}
+
+"""A connection to a list of `Gerbil` values."""
+type GerbilsConnection {
+  """A list of `Gerbil` objects."""
+  nodes: [Gerbil]!
+
+  """
+  A list of edges which contains the `Gerbil` and cursor to aid in pagination.
+  """
+  edges: [GerbilsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Gerbil` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Gerbil` edge in the connection."""
+type GerbilsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Gerbil` at the end of the edge."""
+  node: Gerbil
+}
+
+"""Methods to use when ordering `Gerbil`."""
+enum GerbilsOrderBy {
+  NATURAL
+  ANIMAL_ID_ASC
+  ANIMAL_ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
 """
 The root mutation type which contains root level fields which mutate data.
 """
@@ -344,6 +716,14 @@ type Mutation {
     input: CreateAnimalInput!
   ): CreateAnimalPayload
 
+  """Creates a single `Cat`."""
+  createCat(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateCatInput!
+  ): CreateCatPayload
+
   """Creates a single `Dog`."""
   createDog(
     """
@@ -351,6 +731,14 @@ type Mutation {
     """
     input: CreateDogInput!
   ): CreateDogPayload
+
+  """Creates a single `Gerbil`."""
+  createGerbil(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateGerbilInput!
+  ): CreateGerbilPayload
 
   """Updates a single `Animal` using its globally unique id and a patch."""
   updateAnimalByNodeId(
@@ -368,6 +756,22 @@ type Mutation {
     input: UpdateAnimalInput!
   ): UpdateAnimalPayload
 
+  """Updates a single `Cat` using its globally unique id and a patch."""
+  updateCatByNodeId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateCatByNodeIdInput!
+  ): UpdateCatPayload
+
+  """Updates a single `Cat` using a unique key and a patch."""
+  updateCat(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateCatInput!
+  ): UpdateCatPayload
+
   """Updates a single `Dog` using its globally unique id and a patch."""
   updateDogByNodeId(
     """
@@ -383,6 +787,22 @@ type Mutation {
     """
     input: UpdateDogInput!
   ): UpdateDogPayload
+
+  """Updates a single `Gerbil` using its globally unique id and a patch."""
+  updateGerbilByNodeId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateGerbilByNodeIdInput!
+  ): UpdateGerbilPayload
+
+  """Updates a single `Gerbil` using a unique key and a patch."""
+  updateGerbil(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateGerbilInput!
+  ): UpdateGerbilPayload
 
   """Deletes a single `Animal` using its globally unique id."""
   deleteAnimalByNodeId(
@@ -400,6 +820,22 @@ type Mutation {
     input: DeleteAnimalInput!
   ): DeleteAnimalPayload
 
+  """Deletes a single `Cat` using its globally unique id."""
+  deleteCatByNodeId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteCatByNodeIdInput!
+  ): DeleteCatPayload
+
+  """Deletes a single `Cat` using a unique key."""
+  deleteCat(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteCatInput!
+  ): DeleteCatPayload
+
   """Deletes a single `Dog` using its globally unique id."""
   deleteDogByNodeId(
     """
@@ -415,6 +851,22 @@ type Mutation {
     """
     input: DeleteDogInput!
   ): DeleteDogPayload
+
+  """Deletes a single `Gerbil` using its globally unique id."""
+  deleteGerbilByNodeId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteGerbilByNodeIdInput!
+  ): DeleteGerbilPayload
+
+  """Deletes a single `Gerbil` using a unique key."""
+  deleteGerbil(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteGerbilInput!
+  ): DeleteGerbilPayload
 }
 
 """An object with a globally unique `ID`."""
@@ -505,6 +957,52 @@ type Query implements Node {
     condition: AnimalCondition
   ): [Animal!]
 
+  """Reads and enables pagination through a set of `Cat`."""
+  cats(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Cat`."""
+    orderBy: [CatsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CatCondition
+  ): CatsConnection
+
+  """Reads a set of `Cat`."""
+  catsList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Cat`."""
+    orderBy: [CatsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CatCondition
+  ): [Cat!]
+
   """Reads and enables pagination through a set of `Dog`."""
   dogs(
     """Only read the first `n` values of the set."""
@@ -550,8 +1048,56 @@ type Query implements Node {
     """
     condition: DogCondition
   ): [Dog!]
+
+  """Reads and enables pagination through a set of `Gerbil`."""
+  gerbils(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Gerbil`."""
+    orderBy: [GerbilsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GerbilCondition
+  ): GerbilsConnection
+
+  """Reads a set of `Gerbil`."""
+  gerbilsList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Gerbil`."""
+    orderBy: [GerbilsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GerbilCondition
+  ): [Gerbil!]
   animal(id: Int!): Animal
+  cat(id: Int!): Cat
   dog(id: Int!): Dog
+  gerbil(animalId: Int!): Gerbil
 
   """Reads a single `Animal` using its globally unique `ID`."""
   animalByNodeId(
@@ -559,11 +1105,23 @@ type Query implements Node {
     nodeId: ID!
   ): Animal
 
+  """Reads a single `Cat` using its globally unique `ID`."""
+  catByNodeId(
+    """The globally unique `ID` to be used in selecting a single `Cat`."""
+    nodeId: ID!
+  ): Cat
+
   """Reads a single `Dog` using its globally unique `ID`."""
   dogByNodeId(
     """The globally unique `ID` to be used in selecting a single `Dog`."""
     nodeId: ID!
   ): Dog
+
+  """Reads a single `Gerbil` using its globally unique `ID`."""
+  gerbilByNodeId(
+    """The globally unique `ID` to be used in selecting a single `Gerbil`."""
+    nodeId: ID!
+  ): Gerbil
 }
 
 """All input for the `updateAnimalByNodeId` mutation."""
@@ -621,6 +1179,66 @@ type UpdateAnimalPayload {
     """The method to use when ordering `Animal`."""
     orderBy: [AnimalsOrderBy!] = [PRIMARY_KEY_ASC]
   ): AnimalsEdge
+}
+
+"""All input for the `updateCatByNodeId` mutation."""
+input UpdateCatByNodeIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Cat` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the `Cat` being updated.
+  """
+  patch: CatPatch!
+}
+
+"""All input for the `updateCat` mutation."""
+input UpdateCatInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Cat` being updated.
+  """
+  patch: CatPatch!
+  id: Int!
+}
+
+"""The output of our update `Cat` mutation."""
+type UpdateCatPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Cat` that was updated by this mutation."""
+  cat: Cat
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single `Animal` that is related to this `Cat`."""
+  animal: Animal
+
+  """An edge for our `Cat`. May be used by Relay 1."""
+  catEdge(
+    """The method to use when ordering `Cat`."""
+    orderBy: [CatsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CatsEdge
 }
 
 """All input for the `updateDogByNodeId` mutation."""
@@ -681,4 +1299,64 @@ type UpdateDogPayload {
     """The method to use when ordering `Dog`."""
     orderBy: [DogsOrderBy!] = [PRIMARY_KEY_ASC]
   ): DogsEdge
+}
+
+"""All input for the `updateGerbilByNodeId` mutation."""
+input UpdateGerbilByNodeIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Gerbil` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the `Gerbil` being updated.
+  """
+  patch: GerbilPatch!
+}
+
+"""All input for the `updateGerbil` mutation."""
+input UpdateGerbilInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Gerbil` being updated.
+  """
+  patch: GerbilPatch!
+  animalId: Int!
+}
+
+"""The output of our update `Gerbil` mutation."""
+type UpdateGerbilPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Gerbil` that was updated by this mutation."""
+  gerbil: Gerbil
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single `Animal` that is related to this `Gerbil`."""
+  animal: Animal
+
+  """An edge for our `Gerbil`. May be used by Relay 1."""
+  gerbilEdge(
+    """The method to use when ordering `Gerbil`."""
+    orderBy: [GerbilsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): GerbilsEdge
 }

--- a/tests/animal/schema.simplified.graphql
+++ b/tests/animal/schema.simplified.graphql
@@ -9,7 +9,7 @@ type Animal implements Node {
   dog: Dog
 
   """Reads and enables pagination through a set of `Dog`."""
-  dogsById(
+  dogs(
     """Only read the first `n` values of the set."""
     first: Int
 
@@ -41,7 +41,7 @@ type Animal implements Node {
   cat: Cat
 
   """Reads and enables pagination through a set of `Cat`."""
-  catsById(
+  cats(
     """Only read the first `n` values of the set."""
     first: Int
 

--- a/tests/animal/schema.simplified.graphql
+++ b/tests/animal/schema.simplified.graphql
@@ -1,0 +1,684 @@
+type Animal implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+
+  """Reads a single `Dog` that is related to this `Animal`."""
+  dog: Dog
+
+  """Reads and enables pagination through a set of `Dog`."""
+  dogs(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Dog`."""
+    orderBy: [DogsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: DogCondition
+  ): DogsConnection! @deprecated(reason: "Please use dog instead")
+}
+
+"""
+A condition to be used against `Animal` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input AnimalCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+}
+
+"""An input for mutations affecting `Animal`"""
+input AnimalInput {
+  id: Int
+}
+
+"""
+Represents an update to a `Animal`. Fields that are set will be updated.
+"""
+input AnimalPatch {
+  id: Int
+}
+
+"""A connection to a list of `Animal` values."""
+type AnimalsConnection {
+  """A list of `Animal` objects."""
+  nodes: [Animal]!
+
+  """
+  A list of edges which contains the `Animal` and cursor to aid in pagination.
+  """
+  edges: [AnimalsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Animal` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Animal` edge in the connection."""
+type AnimalsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Animal` at the end of the edge."""
+  node: Animal
+}
+
+"""Methods to use when ordering `Animal`."""
+enum AnimalsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""All input for the create `Animal` mutation."""
+input CreateAnimalInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `Animal` to be created by this mutation."""
+  animal: AnimalInput!
+}
+
+"""The output of our create `Animal` mutation."""
+type CreateAnimalPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Animal` that was created by this mutation."""
+  animal: Animal
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `Animal`. May be used by Relay 1."""
+  animalEdge(
+    """The method to use when ordering `Animal`."""
+    orderBy: [AnimalsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): AnimalsEdge
+}
+
+"""All input for the create `Dog` mutation."""
+input CreateDogInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `Dog` to be created by this mutation."""
+  dog: DogInput!
+}
+
+"""The output of our create `Dog` mutation."""
+type CreateDogPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Dog` that was created by this mutation."""
+  dog: Dog
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single `Animal` that is related to this `Dog`."""
+  animal: Animal
+
+  """An edge for our `Dog`. May be used by Relay 1."""
+  dogEdge(
+    """The method to use when ordering `Dog`."""
+    orderBy: [DogsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): DogsEdge
+}
+
+"""A location in a connection that can be used for resuming pagination."""
+scalar Cursor
+
+"""All input for the `deleteAnimalByNodeId` mutation."""
+input DeleteAnimalByNodeIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Animal` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""All input for the `deleteAnimal` mutation."""
+input DeleteAnimalInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""The output of our delete `Animal` mutation."""
+type DeleteAnimalPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Animal` that was deleted by this mutation."""
+  animal: Animal
+  deletedAnimalNodeId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `Animal`. May be used by Relay 1."""
+  animalEdge(
+    """The method to use when ordering `Animal`."""
+    orderBy: [AnimalsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): AnimalsEdge
+}
+
+"""All input for the `deleteDogByNodeId` mutation."""
+input DeleteDogByNodeIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Dog` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""All input for the `deleteDog` mutation."""
+input DeleteDogInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""The output of our delete `Dog` mutation."""
+type DeleteDogPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Dog` that was deleted by this mutation."""
+  dog: Dog
+  deletedDogNodeId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single `Animal` that is related to this `Dog`."""
+  animal: Animal
+
+  """An edge for our `Dog`. May be used by Relay 1."""
+  dogEdge(
+    """The method to use when ordering `Dog`."""
+    orderBy: [DogsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): DogsEdge
+}
+
+type Dog implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+
+  """Reads a single `Animal` that is related to this `Dog`."""
+  animal: Animal
+}
+
+"""
+A condition to be used against `Dog` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input DogCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+}
+
+"""An input for mutations affecting `Dog`"""
+input DogInput {
+  id: Int!
+}
+
+"""Represents an update to a `Dog`. Fields that are set will be updated."""
+input DogPatch {
+  id: Int
+}
+
+"""A connection to a list of `Dog` values."""
+type DogsConnection {
+  """A list of `Dog` objects."""
+  nodes: [Dog]!
+
+  """
+  A list of edges which contains the `Dog` and cursor to aid in pagination.
+  """
+  edges: [DogsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Dog` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Dog` edge in the connection."""
+type DogsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Dog` at the end of the edge."""
+  node: Dog
+}
+
+"""Methods to use when ordering `Dog`."""
+enum DogsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+The root mutation type which contains root level fields which mutate data.
+"""
+type Mutation {
+  """Creates a single `Animal`."""
+  createAnimal(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateAnimalInput!
+  ): CreateAnimalPayload
+
+  """Creates a single `Dog`."""
+  createDog(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateDogInput!
+  ): CreateDogPayload
+
+  """Updates a single `Animal` using its globally unique id and a patch."""
+  updateAnimalByNodeId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateAnimalByNodeIdInput!
+  ): UpdateAnimalPayload
+
+  """Updates a single `Animal` using a unique key and a patch."""
+  updateAnimal(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateAnimalInput!
+  ): UpdateAnimalPayload
+
+  """Updates a single `Dog` using its globally unique id and a patch."""
+  updateDogByNodeId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateDogByNodeIdInput!
+  ): UpdateDogPayload
+
+  """Updates a single `Dog` using a unique key and a patch."""
+  updateDog(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateDogInput!
+  ): UpdateDogPayload
+
+  """Deletes a single `Animal` using its globally unique id."""
+  deleteAnimalByNodeId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteAnimalByNodeIdInput!
+  ): DeleteAnimalPayload
+
+  """Deletes a single `Animal` using a unique key."""
+  deleteAnimal(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteAnimalInput!
+  ): DeleteAnimalPayload
+
+  """Deletes a single `Dog` using its globally unique id."""
+  deleteDogByNodeId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteDogByNodeIdInput!
+  ): DeleteDogPayload
+
+  """Deletes a single `Dog` using a unique key."""
+  deleteDog(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteDogInput!
+  ): DeleteDogPayload
+}
+
+"""An object with a globally unique `ID`."""
+interface Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: Cursor
+
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+}
+
+"""The root query type which gives access points into the data universe."""
+type Query implements Node {
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
+
+  """
+  The root query type must be a `Node` to work well with Relay 1 mutations. This just resolves to `query`.
+  """
+  nodeId: ID!
+
+  """Fetches an object given its globally unique `ID`."""
+  node(
+    """The globally unique `ID`."""
+    nodeId: ID!
+  ): Node
+
+  """Reads and enables pagination through a set of `Animal`."""
+  animals(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Animal`."""
+    orderBy: [AnimalsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: AnimalCondition
+  ): AnimalsConnection
+
+  """Reads a set of `Animal`."""
+  animalsList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Animal`."""
+    orderBy: [AnimalsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: AnimalCondition
+  ): [Animal!]
+
+  """Reads and enables pagination through a set of `Dog`."""
+  dogs(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Dog`."""
+    orderBy: [DogsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: DogCondition
+  ): DogsConnection
+
+  """Reads a set of `Dog`."""
+  dogsList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Dog`."""
+    orderBy: [DogsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: DogCondition
+  ): [Dog!]
+  animal(id: Int!): Animal
+  dog(id: Int!): Dog
+
+  """Reads a single `Animal` using its globally unique `ID`."""
+  animalByNodeId(
+    """The globally unique `ID` to be used in selecting a single `Animal`."""
+    nodeId: ID!
+  ): Animal
+
+  """Reads a single `Dog` using its globally unique `ID`."""
+  dogByNodeId(
+    """The globally unique `ID` to be used in selecting a single `Dog`."""
+    nodeId: ID!
+  ): Dog
+}
+
+"""All input for the `updateAnimalByNodeId` mutation."""
+input UpdateAnimalByNodeIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Animal` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the `Animal` being updated.
+  """
+  patch: AnimalPatch!
+}
+
+"""All input for the `updateAnimal` mutation."""
+input UpdateAnimalInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Animal` being updated.
+  """
+  patch: AnimalPatch!
+  id: Int!
+}
+
+"""The output of our update `Animal` mutation."""
+type UpdateAnimalPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Animal` that was updated by this mutation."""
+  animal: Animal
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `Animal`. May be used by Relay 1."""
+  animalEdge(
+    """The method to use when ordering `Animal`."""
+    orderBy: [AnimalsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): AnimalsEdge
+}
+
+"""All input for the `updateDogByNodeId` mutation."""
+input UpdateDogByNodeIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Dog` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the `Dog` being updated.
+  """
+  patch: DogPatch!
+}
+
+"""All input for the `updateDog` mutation."""
+input UpdateDogInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Dog` being updated.
+  """
+  patch: DogPatch!
+  id: Int!
+}
+
+"""The output of our update `Dog` mutation."""
+type UpdateDogPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Dog` that was updated by this mutation."""
+  dog: Dog
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single `Animal` that is related to this `Dog`."""
+  animal: Animal
+
+  """An edge for our `Dog`. May be used by Relay 1."""
+  dogEdge(
+    """The method to use when ordering `Dog`."""
+    orderBy: [DogsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): DogsEdge
+}

--- a/tests/animal/schema.sql
+++ b/tests/animal/schema.sql
@@ -1,0 +1,7 @@
+create table animal (
+  id serial primary key
+);
+
+create table dog (
+  id integer primary key references animal
+);

--- a/tests/animal/schema.sql
+++ b/tests/animal/schema.sql
@@ -5,3 +5,11 @@ create table animal (
 create table dog (
   id integer primary key references animal
 );
+
+create table cat (
+  id integer primary key references animal
+);
+
+create table gerbil (
+  animal_id integer primary key references animal
+);

--- a/tests/animal/schema.unsimplified.graphql
+++ b/tests/animal/schema.unsimplified.graphql
@@ -36,6 +36,70 @@ type Animal implements Node {
     """
     condition: DogCondition
   ): DogsConnection! @deprecated(reason: "Please use dogById instead")
+
+  """Reads a single `Cat` that is related to this `Animal`."""
+  catById: Cat
+
+  """Reads and enables pagination through a set of `Cat`."""
+  catsById(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Cat`."""
+    orderBy: [CatsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CatCondition
+  ): CatsConnection! @deprecated(reason: "Please use catById instead")
+
+  """Reads a single `Gerbil` that is related to this `Animal`."""
+  gerbilByAnimalId: Gerbil
+
+  """Reads and enables pagination through a set of `Gerbil`."""
+  gerbilsByAnimalId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Gerbil`."""
+    orderBy: [GerbilsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GerbilCondition
+  ): GerbilsConnection! @deprecated(reason: "Please use gerbilByAnimalId instead")
 }
 
 """
@@ -93,6 +157,70 @@ enum AnimalsOrderBy {
   PRIMARY_KEY_DESC
 }
 
+type Cat implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+
+  """Reads a single `Animal` that is related to this `Cat`."""
+  animalById: Animal
+}
+
+"""
+A condition to be used against `Cat` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input CatCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+}
+
+"""An input for mutations affecting `Cat`"""
+input CatInput {
+  id: Int!
+}
+
+"""Represents an update to a `Cat`. Fields that are set will be updated."""
+input CatPatch {
+  id: Int
+}
+
+"""A connection to a list of `Cat` values."""
+type CatsConnection {
+  """A list of `Cat` objects."""
+  nodes: [Cat]!
+
+  """
+  A list of edges which contains the `Cat` and cursor to aid in pagination.
+  """
+  edges: [CatsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Cat` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Cat` edge in the connection."""
+type CatsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Cat` at the end of the edge."""
+  node: Cat
+}
+
+"""Methods to use when ordering `Cat`."""
+enum CatsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
 """All input for the create `Animal` mutation."""
 input CreateAnimalInput {
   """
@@ -126,6 +254,44 @@ type CreateAnimalPayload {
     """The method to use when ordering `Animal`."""
     orderBy: [AnimalsOrderBy!] = [PRIMARY_KEY_ASC]
   ): AnimalsEdge
+}
+
+"""All input for the create `Cat` mutation."""
+input CreateCatInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `Cat` to be created by this mutation."""
+  cat: CatInput!
+}
+
+"""The output of our create `Cat` mutation."""
+type CreateCatPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Cat` that was created by this mutation."""
+  cat: Cat
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single `Animal` that is related to this `Cat`."""
+  animalById: Animal
+
+  """An edge for our `Cat`. May be used by Relay 1."""
+  catEdge(
+    """The method to use when ordering `Cat`."""
+    orderBy: [CatsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CatsEdge
 }
 
 """All input for the create `Dog` mutation."""
@@ -164,6 +330,44 @@ type CreateDogPayload {
     """The method to use when ordering `Dog`."""
     orderBy: [DogsOrderBy!] = [PRIMARY_KEY_ASC]
   ): DogsEdge
+}
+
+"""All input for the create `Gerbil` mutation."""
+input CreateGerbilInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `Gerbil` to be created by this mutation."""
+  gerbil: GerbilInput!
+}
+
+"""The output of our create `Gerbil` mutation."""
+type CreateGerbilPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Gerbil` that was created by this mutation."""
+  gerbil: Gerbil
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single `Animal` that is related to this `Gerbil`."""
+  animalByAnimalId: Animal
+
+  """An edge for our `Gerbil`. May be used by Relay 1."""
+  gerbilEdge(
+    """The method to use when ordering `Gerbil`."""
+    orderBy: [GerbilsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): GerbilsEdge
 }
 
 """A location in a connection that can be used for resuming pagination."""
@@ -217,6 +421,57 @@ type DeleteAnimalPayload {
   ): AnimalsEdge
 }
 
+"""All input for the `deleteCatById` mutation."""
+input DeleteCatByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the `deleteCat` mutation."""
+input DeleteCatInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Cat` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete `Cat` mutation."""
+type DeleteCatPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Cat` that was deleted by this mutation."""
+  cat: Cat
+  deletedCatId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single `Animal` that is related to this `Cat`."""
+  animalById: Animal
+
+  """An edge for our `Cat`. May be used by Relay 1."""
+  catEdge(
+    """The method to use when ordering `Cat`."""
+    orderBy: [CatsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CatsEdge
+}
+
 """All input for the `deleteDogById` mutation."""
 input DeleteDogByIdInput {
   """
@@ -266,6 +521,57 @@ type DeleteDogPayload {
     """The method to use when ordering `Dog`."""
     orderBy: [DogsOrderBy!] = [PRIMARY_KEY_ASC]
   ): DogsEdge
+}
+
+"""All input for the `deleteGerbilByAnimalId` mutation."""
+input DeleteGerbilByAnimalIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  animalId: Int!
+}
+
+"""All input for the `deleteGerbil` mutation."""
+input DeleteGerbilInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Gerbil` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete `Gerbil` mutation."""
+type DeleteGerbilPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Gerbil` that was deleted by this mutation."""
+  gerbil: Gerbil
+  deletedGerbilId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single `Animal` that is related to this `Gerbil`."""
+  animalByAnimalId: Animal
+
+  """An edge for our `Gerbil`. May be used by Relay 1."""
+  gerbilEdge(
+    """The method to use when ordering `Gerbil`."""
+    orderBy: [GerbilsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): GerbilsEdge
 }
 
 type Dog implements Node {
@@ -332,6 +638,72 @@ enum DogsOrderBy {
   PRIMARY_KEY_DESC
 }
 
+type Gerbil implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  animalId: Int!
+
+  """Reads a single `Animal` that is related to this `Gerbil`."""
+  animalByAnimalId: Animal
+}
+
+"""
+A condition to be used against `Gerbil` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input GerbilCondition {
+  """Checks for equality with the object’s `animalId` field."""
+  animalId: Int
+}
+
+"""An input for mutations affecting `Gerbil`"""
+input GerbilInput {
+  animalId: Int!
+}
+
+"""
+Represents an update to a `Gerbil`. Fields that are set will be updated.
+"""
+input GerbilPatch {
+  animalId: Int
+}
+
+"""A connection to a list of `Gerbil` values."""
+type GerbilsConnection {
+  """A list of `Gerbil` objects."""
+  nodes: [Gerbil]!
+
+  """
+  A list of edges which contains the `Gerbil` and cursor to aid in pagination.
+  """
+  edges: [GerbilsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Gerbil` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Gerbil` edge in the connection."""
+type GerbilsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Gerbil` at the end of the edge."""
+  node: Gerbil
+}
+
+"""Methods to use when ordering `Gerbil`."""
+enum GerbilsOrderBy {
+  NATURAL
+  ANIMAL_ID_ASC
+  ANIMAL_ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
 """
 The root mutation type which contains root level fields which mutate data.
 """
@@ -344,6 +716,14 @@ type Mutation {
     input: CreateAnimalInput!
   ): CreateAnimalPayload
 
+  """Creates a single `Cat`."""
+  createCat(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateCatInput!
+  ): CreateCatPayload
+
   """Creates a single `Dog`."""
   createDog(
     """
@@ -351,6 +731,14 @@ type Mutation {
     """
     input: CreateDogInput!
   ): CreateDogPayload
+
+  """Creates a single `Gerbil`."""
+  createGerbil(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateGerbilInput!
+  ): CreateGerbilPayload
 
   """Updates a single `Animal` using its globally unique id and a patch."""
   updateAnimal(
@@ -368,6 +756,22 @@ type Mutation {
     input: UpdateAnimalByIdInput!
   ): UpdateAnimalPayload
 
+  """Updates a single `Cat` using its globally unique id and a patch."""
+  updateCat(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateCatInput!
+  ): UpdateCatPayload
+
+  """Updates a single `Cat` using a unique key and a patch."""
+  updateCatById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateCatByIdInput!
+  ): UpdateCatPayload
+
   """Updates a single `Dog` using its globally unique id and a patch."""
   updateDog(
     """
@@ -383,6 +787,22 @@ type Mutation {
     """
     input: UpdateDogByIdInput!
   ): UpdateDogPayload
+
+  """Updates a single `Gerbil` using its globally unique id and a patch."""
+  updateGerbil(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateGerbilInput!
+  ): UpdateGerbilPayload
+
+  """Updates a single `Gerbil` using a unique key and a patch."""
+  updateGerbilByAnimalId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateGerbilByAnimalIdInput!
+  ): UpdateGerbilPayload
 
   """Deletes a single `Animal` using its globally unique id."""
   deleteAnimal(
@@ -400,6 +820,22 @@ type Mutation {
     input: DeleteAnimalByIdInput!
   ): DeleteAnimalPayload
 
+  """Deletes a single `Cat` using its globally unique id."""
+  deleteCat(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteCatInput!
+  ): DeleteCatPayload
+
+  """Deletes a single `Cat` using a unique key."""
+  deleteCatById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteCatByIdInput!
+  ): DeleteCatPayload
+
   """Deletes a single `Dog` using its globally unique id."""
   deleteDog(
     """
@@ -415,6 +851,22 @@ type Mutation {
     """
     input: DeleteDogByIdInput!
   ): DeleteDogPayload
+
+  """Deletes a single `Gerbil` using its globally unique id."""
+  deleteGerbil(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteGerbilInput!
+  ): DeleteGerbilPayload
+
+  """Deletes a single `Gerbil` using a unique key."""
+  deleteGerbilByAnimalId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteGerbilByAnimalIdInput!
+  ): DeleteGerbilPayload
 }
 
 """An object with a globally unique `ID`."""
@@ -505,6 +957,52 @@ type Query implements Node {
     condition: AnimalCondition
   ): [Animal!]
 
+  """Reads and enables pagination through a set of `Cat`."""
+  allCats(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Cat`."""
+    orderBy: [CatsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CatCondition
+  ): CatsConnection
+
+  """Reads a set of `Cat`."""
+  allCatsList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Cat`."""
+    orderBy: [CatsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CatCondition
+  ): [Cat!]
+
   """Reads and enables pagination through a set of `Dog`."""
   allDogs(
     """Only read the first `n` values of the set."""
@@ -550,8 +1048,56 @@ type Query implements Node {
     """
     condition: DogCondition
   ): [Dog!]
+
+  """Reads and enables pagination through a set of `Gerbil`."""
+  allGerbils(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Gerbil`."""
+    orderBy: [GerbilsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GerbilCondition
+  ): GerbilsConnection
+
+  """Reads a set of `Gerbil`."""
+  allGerbilsList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Gerbil`."""
+    orderBy: [GerbilsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: GerbilCondition
+  ): [Gerbil!]
   animalById(id: Int!): Animal
+  catById(id: Int!): Cat
   dogById(id: Int!): Dog
+  gerbilByAnimalId(animalId: Int!): Gerbil
 
   """Reads a single `Animal` using its globally unique `ID`."""
   animal(
@@ -559,11 +1105,23 @@ type Query implements Node {
     nodeId: ID!
   ): Animal
 
+  """Reads a single `Cat` using its globally unique `ID`."""
+  cat(
+    """The globally unique `ID` to be used in selecting a single `Cat`."""
+    nodeId: ID!
+  ): Cat
+
   """Reads a single `Dog` using its globally unique `ID`."""
   dog(
     """The globally unique `ID` to be used in selecting a single `Dog`."""
     nodeId: ID!
   ): Dog
+
+  """Reads a single `Gerbil` using its globally unique `ID`."""
+  gerbil(
+    """The globally unique `ID` to be used in selecting a single `Gerbil`."""
+    nodeId: ID!
+  ): Gerbil
 }
 
 """All input for the `updateAnimalById` mutation."""
@@ -621,6 +1179,66 @@ type UpdateAnimalPayload {
     """The method to use when ordering `Animal`."""
     orderBy: [AnimalsOrderBy!] = [PRIMARY_KEY_ASC]
   ): AnimalsEdge
+}
+
+"""All input for the `updateCatById` mutation."""
+input UpdateCatByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Cat` being updated.
+  """
+  catPatch: CatPatch!
+  id: Int!
+}
+
+"""All input for the `updateCat` mutation."""
+input UpdateCatInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Cat` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the `Cat` being updated.
+  """
+  catPatch: CatPatch!
+}
+
+"""The output of our update `Cat` mutation."""
+type UpdateCatPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Cat` that was updated by this mutation."""
+  cat: Cat
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single `Animal` that is related to this `Cat`."""
+  animalById: Animal
+
+  """An edge for our `Cat`. May be used by Relay 1."""
+  catEdge(
+    """The method to use when ordering `Cat`."""
+    orderBy: [CatsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CatsEdge
 }
 
 """All input for the `updateDogById` mutation."""
@@ -681,4 +1299,64 @@ type UpdateDogPayload {
     """The method to use when ordering `Dog`."""
     orderBy: [DogsOrderBy!] = [PRIMARY_KEY_ASC]
   ): DogsEdge
+}
+
+"""All input for the `updateGerbilByAnimalId` mutation."""
+input UpdateGerbilByAnimalIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Gerbil` being updated.
+  """
+  gerbilPatch: GerbilPatch!
+  animalId: Int!
+}
+
+"""All input for the `updateGerbil` mutation."""
+input UpdateGerbilInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Gerbil` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the `Gerbil` being updated.
+  """
+  gerbilPatch: GerbilPatch!
+}
+
+"""The output of our update `Gerbil` mutation."""
+type UpdateGerbilPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Gerbil` that was updated by this mutation."""
+  gerbil: Gerbil
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single `Animal` that is related to this `Gerbil`."""
+  animalByAnimalId: Animal
+
+  """An edge for our `Gerbil`. May be used by Relay 1."""
+  gerbilEdge(
+    """The method to use when ordering `Gerbil`."""
+    orderBy: [GerbilsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): GerbilsEdge
 }

--- a/tests/animal/schema.unsimplified.graphql
+++ b/tests/animal/schema.unsimplified.graphql
@@ -1,0 +1,684 @@
+type Animal implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+
+  """Reads a single `Dog` that is related to this `Animal`."""
+  dogById: Dog
+
+  """Reads and enables pagination through a set of `Dog`."""
+  dogsById(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Dog`."""
+    orderBy: [DogsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: DogCondition
+  ): DogsConnection! @deprecated(reason: "Please use dogById instead")
+}
+
+"""
+A condition to be used against `Animal` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input AnimalCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+}
+
+"""An input for mutations affecting `Animal`"""
+input AnimalInput {
+  id: Int
+}
+
+"""
+Represents an update to a `Animal`. Fields that are set will be updated.
+"""
+input AnimalPatch {
+  id: Int
+}
+
+"""A connection to a list of `Animal` values."""
+type AnimalsConnection {
+  """A list of `Animal` objects."""
+  nodes: [Animal]!
+
+  """
+  A list of edges which contains the `Animal` and cursor to aid in pagination.
+  """
+  edges: [AnimalsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Animal` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Animal` edge in the connection."""
+type AnimalsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Animal` at the end of the edge."""
+  node: Animal
+}
+
+"""Methods to use when ordering `Animal`."""
+enum AnimalsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""All input for the create `Animal` mutation."""
+input CreateAnimalInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `Animal` to be created by this mutation."""
+  animal: AnimalInput!
+}
+
+"""The output of our create `Animal` mutation."""
+type CreateAnimalPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Animal` that was created by this mutation."""
+  animal: Animal
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `Animal`. May be used by Relay 1."""
+  animalEdge(
+    """The method to use when ordering `Animal`."""
+    orderBy: [AnimalsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): AnimalsEdge
+}
+
+"""All input for the create `Dog` mutation."""
+input CreateDogInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `Dog` to be created by this mutation."""
+  dog: DogInput!
+}
+
+"""The output of our create `Dog` mutation."""
+type CreateDogPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Dog` that was created by this mutation."""
+  dog: Dog
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single `Animal` that is related to this `Dog`."""
+  animalById: Animal
+
+  """An edge for our `Dog`. May be used by Relay 1."""
+  dogEdge(
+    """The method to use when ordering `Dog`."""
+    orderBy: [DogsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): DogsEdge
+}
+
+"""A location in a connection that can be used for resuming pagination."""
+scalar Cursor
+
+"""All input for the `deleteAnimalById` mutation."""
+input DeleteAnimalByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the `deleteAnimal` mutation."""
+input DeleteAnimalInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Animal` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete `Animal` mutation."""
+type DeleteAnimalPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Animal` that was deleted by this mutation."""
+  animal: Animal
+  deletedAnimalId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `Animal`. May be used by Relay 1."""
+  animalEdge(
+    """The method to use when ordering `Animal`."""
+    orderBy: [AnimalsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): AnimalsEdge
+}
+
+"""All input for the `deleteDogById` mutation."""
+input DeleteDogByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the `deleteDog` mutation."""
+input DeleteDogInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Dog` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete `Dog` mutation."""
+type DeleteDogPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Dog` that was deleted by this mutation."""
+  dog: Dog
+  deletedDogId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single `Animal` that is related to this `Dog`."""
+  animalById: Animal
+
+  """An edge for our `Dog`. May be used by Relay 1."""
+  dogEdge(
+    """The method to use when ordering `Dog`."""
+    orderBy: [DogsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): DogsEdge
+}
+
+type Dog implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+
+  """Reads a single `Animal` that is related to this `Dog`."""
+  animalById: Animal
+}
+
+"""
+A condition to be used against `Dog` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input DogCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+}
+
+"""An input for mutations affecting `Dog`"""
+input DogInput {
+  id: Int!
+}
+
+"""Represents an update to a `Dog`. Fields that are set will be updated."""
+input DogPatch {
+  id: Int
+}
+
+"""A connection to a list of `Dog` values."""
+type DogsConnection {
+  """A list of `Dog` objects."""
+  nodes: [Dog]!
+
+  """
+  A list of edges which contains the `Dog` and cursor to aid in pagination.
+  """
+  edges: [DogsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Dog` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Dog` edge in the connection."""
+type DogsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Dog` at the end of the edge."""
+  node: Dog
+}
+
+"""Methods to use when ordering `Dog`."""
+enum DogsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+The root mutation type which contains root level fields which mutate data.
+"""
+type Mutation {
+  """Creates a single `Animal`."""
+  createAnimal(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateAnimalInput!
+  ): CreateAnimalPayload
+
+  """Creates a single `Dog`."""
+  createDog(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateDogInput!
+  ): CreateDogPayload
+
+  """Updates a single `Animal` using its globally unique id and a patch."""
+  updateAnimal(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateAnimalInput!
+  ): UpdateAnimalPayload
+
+  """Updates a single `Animal` using a unique key and a patch."""
+  updateAnimalById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateAnimalByIdInput!
+  ): UpdateAnimalPayload
+
+  """Updates a single `Dog` using its globally unique id and a patch."""
+  updateDog(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateDogInput!
+  ): UpdateDogPayload
+
+  """Updates a single `Dog` using a unique key and a patch."""
+  updateDogById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateDogByIdInput!
+  ): UpdateDogPayload
+
+  """Deletes a single `Animal` using its globally unique id."""
+  deleteAnimal(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteAnimalInput!
+  ): DeleteAnimalPayload
+
+  """Deletes a single `Animal` using a unique key."""
+  deleteAnimalById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteAnimalByIdInput!
+  ): DeleteAnimalPayload
+
+  """Deletes a single `Dog` using its globally unique id."""
+  deleteDog(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteDogInput!
+  ): DeleteDogPayload
+
+  """Deletes a single `Dog` using a unique key."""
+  deleteDogById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteDogByIdInput!
+  ): DeleteDogPayload
+}
+
+"""An object with a globally unique `ID`."""
+interface Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: Cursor
+
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+}
+
+"""The root query type which gives access points into the data universe."""
+type Query implements Node {
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
+
+  """
+  The root query type must be a `Node` to work well with Relay 1 mutations. This just resolves to `query`.
+  """
+  nodeId: ID!
+
+  """Fetches an object given its globally unique `ID`."""
+  node(
+    """The globally unique `ID`."""
+    nodeId: ID!
+  ): Node
+
+  """Reads and enables pagination through a set of `Animal`."""
+  allAnimals(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Animal`."""
+    orderBy: [AnimalsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: AnimalCondition
+  ): AnimalsConnection
+
+  """Reads a set of `Animal`."""
+  allAnimalsList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Animal`."""
+    orderBy: [AnimalsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: AnimalCondition
+  ): [Animal!]
+
+  """Reads and enables pagination through a set of `Dog`."""
+  allDogs(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Dog`."""
+    orderBy: [DogsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: DogCondition
+  ): DogsConnection
+
+  """Reads a set of `Dog`."""
+  allDogsList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """The method to use when ordering `Dog`."""
+    orderBy: [DogsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: DogCondition
+  ): [Dog!]
+  animalById(id: Int!): Animal
+  dogById(id: Int!): Dog
+
+  """Reads a single `Animal` using its globally unique `ID`."""
+  animal(
+    """The globally unique `ID` to be used in selecting a single `Animal`."""
+    nodeId: ID!
+  ): Animal
+
+  """Reads a single `Dog` using its globally unique `ID`."""
+  dog(
+    """The globally unique `ID` to be used in selecting a single `Dog`."""
+    nodeId: ID!
+  ): Dog
+}
+
+"""All input for the `updateAnimalById` mutation."""
+input UpdateAnimalByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Animal` being updated.
+  """
+  animalPatch: AnimalPatch!
+  id: Int!
+}
+
+"""All input for the `updateAnimal` mutation."""
+input UpdateAnimalInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Animal` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the `Animal` being updated.
+  """
+  animalPatch: AnimalPatch!
+}
+
+"""The output of our update `Animal` mutation."""
+type UpdateAnimalPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Animal` that was updated by this mutation."""
+  animal: Animal
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `Animal`. May be used by Relay 1."""
+  animalEdge(
+    """The method to use when ordering `Animal`."""
+    orderBy: [AnimalsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): AnimalsEdge
+}
+
+"""All input for the `updateDogById` mutation."""
+input UpdateDogByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Dog` being updated.
+  """
+  dogPatch: DogPatch!
+  id: Int!
+}
+
+"""All input for the `updateDog` mutation."""
+input UpdateDogInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Dog` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the `Dog` being updated.
+  """
+  dogPatch: DogPatch!
+}
+
+"""The output of our update `Dog` mutation."""
+type UpdateDogPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Dog` that was updated by this mutation."""
+  dog: Dog
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single `Animal` that is related to this `Dog`."""
+  animalById: Animal
+
+  """An edge for our `Dog`. May be used by Relay 1."""
+  dogEdge(
+    """The method to use when ordering `Dog`."""
+    orderBy: [DogsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): DogsEdge
+}


### PR DESCRIPTION
## Description

<!-- If this PR adds a feature, what does it add and what was the motivation for it? -->
<!-- If this PR fixes an issue, what is the issue? -->
<!-- Please link to the relevant GitHub issues/Discord discussion/etc as appropriate -->
Fixes #34

One unsolved issue is that I think I'm also supposed to fix `manyRelationByKeysSimple`, but it's never called for the `animal` test, and there is no `dogByAnimalIdList` simple connection generated for the unsimplified case. Is it broken by my change or related to another plugin?
## Performance impact
unknown
<!-- Detail any impact on performance of this PR, or put 'unknown' if not known -->

## Security impact
unknown
<!-- Detail any impact on security of this PR, or put 'unknown' if not known -->

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
